### PR TITLE
Cleanup editor scene

### DIFF
--- a/src/editor/src/ContentPanel.cpp
+++ b/src/editor/src/ContentPanel.cpp
@@ -10,6 +10,7 @@
 #include "Result.hpp"
 #include "Loaders/GltfLoadFunctions.hpp"
 #include "UI.hpp"
+#include "UIUtils.hpp"
 #include "VirtualFilesystem.hpp"
 #include "WindowManager.hpp"
 #include "crypto/Hashing.hpp"
@@ -50,7 +51,7 @@ void Hush::ContentPanel::OnRender() {
 			UI::S_INITIALIZED = true;
 		}
 		ImGui::Text("Current Working Directory: %s", this->m_currentWorkingDirectory.c_str());
-		bool isMouseInScene = !ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow | ImGuiHoveredFlags_AllowWhenBlockedByActiveItem);
+		bool isMouseInScene = UIUtils::IsMouseInScene();
 		this->DrawFiles(isMouseInScene);
 		const ImGuiPayload *payload = ImGui::GetDragDropPayload();
 		if (isMouseInScene && payload != nullptr && ImGui::IsMouseReleased(ImGuiMouseButton_Left)) {

--- a/src/editor/src/UI.cpp
+++ b/src/editor/src/UI.cpp
@@ -1,6 +1,5 @@
 #include "UI.hpp"
 #include "CommandPanel.hpp"
-#include "DevPanel.hpp"
 #include "HierarchyPanel.hpp"
 #include "InputManager.hpp"
 #include "InspectorPanel.hpp"
@@ -31,7 +30,6 @@ void Hush::UI::Init(Scene *parentScene)
 	ADD_PANEL(parentScene, this->m_activePanels, ContentPanel);
 	ADD_PANEL(parentScene, this->m_activePanels, CommandPanel);
 	ADD_PANEL(parentScene, this->m_activePanels, InspectorPanel);
-	ADD_PANEL(parentScene, this->m_activePanels, DevPanel);
 }
 
 void Hush::UI::DrawPanels()

--- a/src/editor/src/UI.cpp
+++ b/src/editor/src/UI.cpp
@@ -1,5 +1,6 @@
 #include "UI.hpp"
 #include "CommandPanel.hpp"
+#include "DevPanel.hpp"
 #include "HierarchyPanel.hpp"
 #include "InputManager.hpp"
 #include "InspectorPanel.hpp"
@@ -11,8 +12,8 @@
 #include <imgui/imgui.h>
 #include <imgui/imgui_internal.h>
 #include "ContentPanel.hpp"
-#include "Components/Transform.hpp"
 
+// NOLINTNEXTLINE
 #define ADD_PANEL(activeScene, panelsMap, panelType) panelsMap[typeid(panelType)] = CreatePanel<panelType>(activeScene)
 
 Hush::UI::UI()
@@ -30,6 +31,7 @@ void Hush::UI::Init(Scene *parentScene)
 	ADD_PANEL(parentScene, this->m_activePanels, ContentPanel);
 	ADD_PANEL(parentScene, this->m_activePanels, CommandPanel);
 	ADD_PANEL(parentScene, this->m_activePanels, InspectorPanel);
+	ADD_PANEL(parentScene, this->m_activePanels, DevPanel);
 }
 
 void Hush::UI::DrawPanels()

--- a/src/editor/src/UIUtils.hpp
+++ b/src/editor/src/UIUtils.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "imgui/imgui.h"
+
+namespace UIUtils {
+	inline bool IsMouseInScene() {
+		return !ImGui::IsWindowHovered(ImGuiHoveredFlags_AnyWindow | ImGuiHoveredFlags_AllowWhenBlockedByActiveItem);
+	}
+}

--- a/src/editor/src/systems/EditorCameraSystem.cpp
+++ b/src/editor/src/systems/EditorCameraSystem.cpp
@@ -6,7 +6,6 @@
 #include "../UIUtils.hpp"
 #include <glm/ext/vector_float3.hpp>
 
-
 constexpr float CAM_PITCH_MIN = -90.f * Hush::MathUtils::DEG_TO_RAD;
 constexpr float CAM_PITCH_MAX = 90.f * Hush::MathUtils::DEG_TO_RAD;
 

--- a/src/editor/src/systems/EditorCameraSystem.cpp
+++ b/src/editor/src/systems/EditorCameraSystem.cpp
@@ -1,8 +1,14 @@
 #include "EditorCameraSystem.hpp"
-#include "HushEngine.hpp"
+#include "MathUtils.hpp"
 #include "Renderer.hpp"
+#include "Scene.hpp"
 #include "WindowManager.hpp"
+#include "../UIUtils.hpp"
 #include <glm/ext/vector_float3.hpp>
+
+
+constexpr float CAM_PITCH_MIN = -90.f * Hush::MathUtils::DEG_TO_RAD;
+constexpr float CAM_PITCH_MAX = 90.f * Hush::MathUtils::DEG_TO_RAD;
 
 void Hush::EditorCameraSystem::Init() {
 	IRenderer* renderer = WindowManager::GetMainWindow()->GetInternalRenderer();
@@ -21,7 +27,7 @@ void Hush::EditorCameraSystem::OnUpdate(float delta) {
 	glm::mat4 viewMatrix = this->m_editorCamera->GetViewMatrix();
 	glm::vec3 forward = -glm::vec3(viewMatrix[0][2], viewMatrix[1][2], viewMatrix[2][2]);
 	glm::vec3& positionRef = this->m_editorCamera->GetPosition();
-	if (InputManager::GetMouseScrollAcceleration().y != 0.0F)
+	if (InputManager::GetMouseScrollAcceleration().y != 0.0F && UIUtils::IsMouseInScene())
 	{
 		constexpr float zoomSpeed = 100.F;
 		positionRef += forward * InputManager::GetMouseScrollAcceleration().y * zoomSpeed * delta;
@@ -85,7 +91,7 @@ void Hush::EditorCameraSystem::OnUpdate(float delta) {
 		float& yaw = this->m_editorCamera->GetYaw();
 		float& pitch = this->m_editorCamera->GetPitch();
 		yaw += mouseAcceleration.x * mouseLookSpeed * delta;
-		pitch += mouseAcceleration.y * mouseLookSpeed * delta;
+		pitch = MathUtils::Clamp(pitch + mouseAcceleration.y * mouseLookSpeed * delta, CAM_PITCH_MIN, CAM_PITCH_MAX);
 	}
 }
 

--- a/src/editor/src/systems/EditorCameraSystem.cpp
+++ b/src/editor/src/systems/EditorCameraSystem.cpp
@@ -6,8 +6,8 @@
 #include "../UIUtils.hpp"
 #include <glm/ext/vector_float3.hpp>
 
-constexpr float CAM_PITCH_MIN = -90.f * Hush::MathUtils::DEG_TO_RAD;
-constexpr float CAM_PITCH_MAX = 90.f * Hush::MathUtils::DEG_TO_RAD;
+constexpr float CAM_PITCH_MIN = -89.5f * Hush::MathUtils::DEG_TO_RAD;
+constexpr float CAM_PITCH_MAX = 89.5f * Hush::MathUtils::DEG_TO_RAD;
 
 void Hush::EditorCameraSystem::Init() {
 	IRenderer* renderer = WindowManager::GetMainWindow()->GetInternalRenderer();

--- a/src/engine_core/utils/src/MathUtils.hpp
+++ b/src/engine_core/utils/src/MathUtils.hpp
@@ -4,7 +4,7 @@
 namespace Hush::MathUtils
 {
 	constexpr float PI = 3.1415926535897932384626433832795f;
-	constexpr float TAU = PI * 2;
+	constexpr float TAU = PI * 2.0f;
 	constexpr float RAD_TO_DEG = 180.0f / PI;
 	constexpr float DEG_TO_RAD = PI / 180.0f;
 	

--- a/src/engine_core/utils/src/MathUtils.hpp
+++ b/src/engine_core/utils/src/MathUtils.hpp
@@ -3,7 +3,11 @@
 
 namespace Hush::MathUtils
 {
-
+	constexpr float PI = 3.1415926535897932384626433832795f;
+	constexpr float TAU = PI * 2;
+	constexpr float RAD_TO_DEG = 180.0f / PI;
+	constexpr float DEG_TO_RAD = PI / 180.0f;
+	
 	inline float Clamp(float value, float min, float max)
 	{
 		const float t = value < min ? min : value;

--- a/third_party/imgui/include/imguizmo/ImGuizmo.cpp
+++ b/third_party/imgui/include/imguizmo/ImGuizmo.cpp
@@ -637,22 +637,24 @@ namespace IMGUIZMO_NAMESPACE
    Style::Style()
    {
       // default values
-      TranslationLineThickness   = 3.0f;
-      TranslationLineArrowSize   = 6.0f;
-      RotationLineThickness      = 2.0f;
-      RotationOuterLineThickness = 3.0f;
-      ScaleLineThickness         = 3.0f;
+      // HUSH_MOD: Most default values changed to bigger numbers
+      TranslationLineThickness   = 10.0f;
+      TranslationLineArrowSize   = 10.0f;
+      RotationLineThickness      = 10.0f;
+      RotationOuterLineThickness = 2.0f;
+      ScaleLineThickness         = 10.0f;
       ScaleLineCircleSize        = 6.0f;
       HatchedAxisLineThickness   = 6.0f;
       CenterCircleSize           = 6.0f;
 
       // initialize default colors
+      // HUSH_MOD: Changed colors to make it prettier
       Colors[DIRECTION_X]           = ImVec4(0.666f, 0.000f, 0.000f, 1.000f);
       Colors[DIRECTION_Y]           = ImVec4(0.000f, 0.666f, 0.000f, 1.000f);
-      Colors[DIRECTION_Z]           = ImVec4(0.000f, 0.000f, 0.666f, 1.000f);
-      Colors[PLANE_X]               = ImVec4(0.666f, 0.000f, 0.000f, 0.380f);
-      Colors[PLANE_Y]               = ImVec4(0.000f, 0.666f, 0.000f, 0.380f);
-      Colors[PLANE_Z]               = ImVec4(0.000f, 0.000f, 0.666f, 0.380f);
+      Colors[DIRECTION_Z]           = ImVec4(0.3767f, 0.333f, 0.666f, 1.000f);
+      Colors[PLANE_X]               = Colors[DIRECTION_X];
+      Colors[PLANE_Y]               = Colors[DIRECTION_Y];
+      Colors[PLANE_Z]               = Colors[DIRECTION_Z];
       Colors[SELECTION]             = ImVec4(1.000f, 0.500f, 0.062f, 0.541f);
       Colors[INACTIVE]              = ImVec4(0.600f, 0.600f, 0.600f, 0.600f);
       Colors[TRANSLATION_LINE]      = ImVec4(0.666f, 0.666f, 0.666f, 0.666f);

--- a/third_party/imgui/include/imguizmo/ImGuizmo.h
+++ b/third_party/imgui/include/imguizmo/ImGuizmo.h
@@ -48,12 +48,14 @@ void EditTransform(const Camera& camera, matrix_t& matrix)
 {
    static ImGuizmo::OPERATION mCurrentGizmoOperation(ImGuizmo::ROTATE);
    static ImGuizmo::MODE mCurrentGizmoMode(ImGuizmo::WORLD);
-   if (ImGui::IsKeyPressed(90))
-      mCurrentGizmoOperation = ImGuizmo::TRANSLATE;
-   if (ImGui::IsKeyPressed(69))
-      mCurrentGizmoOperation = ImGuizmo::ROTATE;
-   if (ImGui::IsKeyPressed(82)) // r Key
-      mCurrentGizmoOperation = ImGuizmo::SCALE;
+   // HUSH_CUSTOM: We do not want to inherit this behaviour
+   // 
+   // if (ImGui::IsKeyPressed(90))
+   //    mCurrentGizmoOperation = ImGuizmo::TRANSLATE;
+   // if (ImGui::IsKeyPressed(69))
+   //    mCurrentGizmoOperation = ImGuizmo::ROTATE;
+   // if (ImGui::IsKeyPressed(82)) // r Key
+   //    mCurrentGizmoOperation = ImGuizmo::SCALE;
    if (ImGui::RadioButton("Translate", mCurrentGizmoOperation == ImGuizmo::TRANSLATE))
       mCurrentGizmoOperation = ImGuizmo::TRANSLATE;
    ImGui::SameLine();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Zoom now only activates when the cursor is over the scene; drag-and-drop is similarly gated to avoid UI interference.
  * Editor camera pitch is clamped to ±89.5°, preventing flips and over-rotation.

* **Style**
  * Gizmo visuals refreshed with thicker lines and adjusted colors for improved visibility.

* **Chores**
  * Example gizmo keyboard shortcuts in the sample code disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->