### PR TITLE
feat: added tracy support

### DIFF
--- a/cmake/program-options.cmake
+++ b/cmake/program-options.cmake
@@ -3,6 +3,7 @@
 option(HUSH_ENABLE_LTO "Enable Link-Time Optimization" OFF)
 option(HUSH_ENABLE_TESTS "Enable tests" ON)
 option(HUSH_ENABLE_DOCS "Enable documentation" ON)
+option(HUSH_ENABLE_PROFILING "Enable Tracy profiler instrumentation" ON)
 
 if (HUSH_ENABLE_LTO)
     include(CheckIPOSupported)

--- a/src/cmake/utils.cmake
+++ b/src/cmake/utils.cmake
@@ -200,7 +200,7 @@ macro(add_test_target)
         target_link_libraries(${TEST_TARGET_NAME} PRIVATE ${TEST_ENGINE_TARGET} Hush::Log Catch2::Catch2WithMain)
         set_all_warnings(${TEST_TARGET_NAME})
 
-        catch_discover_tests(${TEST_TARGET_NAME})
+        catch_discover_tests(${TEST_TARGET_NAME} DISCOVERY_MODE PRE_TEST)
 
         if (${HUSH_ENABLE_LTO})
             set_property(TARGET ${TEST_TARGET_NAME} PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)

--- a/src/editor/src/EditorApp.cpp
+++ b/src/editor/src/EditorApp.cpp
@@ -34,6 +34,7 @@
 
 #include <algorithm>
 #include <memory>
+#include "Profiling.hpp"
 
 // This is temporary lol
 #if __has_include("../../bindings/HushBindings.cpp")
@@ -80,11 +81,11 @@ public:
 		this->m_resourceManager = &entt.AddComponent<Hush::ResourceManager>();
 
 		// Scriptingb
-		constexpr std::string_view scriptingProjDllPath =
-			"C:/Users/nefes/Personal/HushBindingGen/build/Debug_Win64/beef-hush/beef-hush.dll";
+		// constexpr std::string_view scriptingProjDllPath =
+		// 	"C:/Users/nefes/Personal/HushBindingGen/build/Debug_Win64/beef-hush/beef-hush.dll";
 		this->m_scriptingHost = &entt.AddComponent<Hush::ScriptingHost>();
-		this->m_scriptingHost->Initialize(scriptingProjDllPath);
-		this->m_scriptingHost->GetStartScriptingConnectionFn()(&HUSH_FUNCPTR_TABLE, this->m_scene->GetEngine());
+		// this->m_scriptingHost->Initialize(scriptingProjDllPath);
+		// this->m_scriptingHost->GetStartScriptingConnectionFn()(&HUSH_FUNCPTR_TABLE, this->m_scene->GetEngine());
 
 		Hush::VirtualFilesystem &vfs = entt.AddComponent<Hush::VirtualFilesystem>();
 		vfs.MountFileSystem<Hush::CFileSystem>("res://", HUSH_DEFAULT_PROJECT_DIR);
@@ -148,6 +149,7 @@ public:
 
 	void OnRender(float delta) override
 	{
+		ZoneScopedN("EditorApp::OnRender");
 		// Update the scene panel texture BEFORE building ImGui draw data.
 		// The texture was realized during the previous frame's OnPreRender
 		// (graph compile + resource realization).
@@ -192,6 +194,7 @@ public:
 
 	void OnPreRender() override
 	{
+		ZoneScopedN("EditorApp::OnPreRender");
 		// If the scene panel was resized last frame, invalidate the render
 		// graph BEFORE Scene::PreRender() so the RenderGraphSystem takes
 		// the slow path (Reset + rebuild + compile).  The new texture is

--- a/src/editor/src/systems/EditorCameraSystem.cpp
+++ b/src/editor/src/systems/EditorCameraSystem.cpp
@@ -1,5 +1,6 @@
 #include "EditorCameraSystem.hpp"
 #include "MathUtils.hpp"
+#include "Profiling.hpp"
 #include "Renderer.hpp"
 #include "Scene.hpp"
 #include "WindowManager.hpp"
@@ -28,6 +29,7 @@ void Hush::EditorCameraSystem::OnShutdown()
 
 void Hush::EditorCameraSystem::OnUpdate(float delta)
 {
+	ZoneScoped;
 	// We need to retrieve the camera and editor info references every frame because the scene might have been reloaded,
 	// which destroys all existing entities and components.  This is a bit hacky but it avoids having to add a more
 	// complex event system just for this.

--- a/src/editor/src/systems/RenderingSystem.cpp
+++ b/src/editor/src/systems/RenderingSystem.cpp
@@ -1,6 +1,7 @@
 #include "RenderingSystem.hpp"
 #include "Components/MeshReference.hpp"
 #include "Components/WorldTransform.hpp"
+#include "Profiling.hpp"
 #include "Query.hpp"
 #include "Scene.hpp"
 #include "WindowManager.hpp"
@@ -30,6 +31,7 @@ void Hush::RenderingSystem::OnRender()
 
 void Hush::RenderingSystem::OnPreRender()
 {
+	ZoneScoped;
 	// TODO: Update camera view matrix and everything else in the scene data here
 	IRenderer *renderer = WindowManager::GetMainWindow()->GetInternalRenderer();
 	this->m_renderableTargetsQuery.Each([&renderer](Entity &_, const MeshReference &mesh, const WorldTransform &xform) {

--- a/src/engine_core/cmake/deps.cmake
+++ b/src/engine_core/cmake/deps.cmake
@@ -43,3 +43,8 @@ find_package(boost_unordered REQUIRED CONFIG)
 
 # Slang shader compiler
 find_package(slang CONFIG REQUIRED)
+
+# Tracy profiler
+if (HUSH_ENABLE_PROFILING)
+    find_package(Tracy CONFIG REQUIRED)
+endif()

--- a/src/engine_core/core/src/Scene.cpp
+++ b/src/engine_core/core/src/Scene.cpp
@@ -10,6 +10,7 @@
 #include "utils/ParallelUtils.hpp"
 #include <flecs.h>
 #include <flecs/addons/flecs_c.h>
+#include "Profiling.hpp"
 
 constexpr std::size_t DEFAULT_SYSTEMS_CAPACITY = 128;
 
@@ -29,6 +30,7 @@ Hush::Scene::~Scene()
 
 void Hush::Scene::Init()
 {
+	ZoneScoped;
 	for (const std::vector<ISystem *> &systemBucket : m_systems)
 	{
 		Threading::Wait(Threading::ParallelFor(m_threadPool, systemBucket.begin(), systemBucket.end(),
@@ -46,6 +48,7 @@ void Hush::Scene::Init()
 
 void Hush::Scene::Update(float delta)
 {
+	ZoneScoped;
 	for (const std::vector<ISystem *> &systemBucket : m_systems)
 	{
 		Threading::Wait(
@@ -65,6 +68,7 @@ void Hush::Scene::Update(float delta)
 
 void Hush::Scene::FixedUpdate(float delta)
 {
+	ZoneScoped;
 	for (const std::vector<ISystem *> &systemBucket : m_systems)
 	{
 		Threading::Wait(
@@ -85,6 +89,7 @@ void Hush::Scene::FixedUpdate(float delta)
 
 void Hush::Scene::PreRender()
 {
+	ZoneScoped;
 	for (const std::vector<ISystem *> &systemBucket : m_systems)
 	{
 		Threading::Wait(Threading::ParallelFor(m_threadPool, systemBucket.begin(), systemBucket.end(),
@@ -100,6 +105,7 @@ void Hush::Scene::PreRender()
 }
 void Hush::Scene::Render()
 {
+	ZoneScoped;
 	for (const std::vector<ISystem *> &systemBucket : m_systems)
 	{
 		Threading::Wait(Threading::ParallelFor(m_threadPool, systemBucket.begin(), systemBucket.end(),
@@ -116,6 +122,7 @@ void Hush::Scene::Render()
 
 void Hush::Scene::PostRender()
 {
+	ZoneScoped;
 	for (const std::vector<ISystem *> &systemBucket : m_systems)
 	{
 		Threading::Wait(Threading::ParallelFor(m_threadPool, systemBucket.begin(), systemBucket.end(),
@@ -132,6 +139,7 @@ void Hush::Scene::PostRender()
 
 void Hush::Scene::Shutdown()
 {
+	ZoneScoped;
 	for (const std::vector<ISystem *> &systemBucket : m_systems)
 	{
 		Threading::Wait(Threading::ParallelFor(m_threadPool, systemBucket.begin(), systemBucket.end(),

--- a/src/engine_core/core/src/TransformationSystem.cpp
+++ b/src/engine_core/core/src/TransformationSystem.cpp
@@ -2,6 +2,7 @@
 #include "Components/LocalTransform.hpp"
 #include "Components/WorldTransform.hpp"
 #include "Mat4Math.hpp"
+#include "Profiling.hpp"
 #include "Scene.hpp"
 
 void Hush::TransformationSystem::Init()
@@ -15,6 +16,7 @@ void Hush::TransformationSystem::OnShutdown()
 
 void Hush::TransformationSystem::OnUpdate(float delta)
 {
+	ZoneScoped;
 	(void)delta;
 	this->m_transformableEntitiesQuery.Each([](Entity &entity, WorldTransform &worldXform, LocalTransform &localXform) {
 		// Get the parents xform and multiply that by the local xform... that now becomes the global xform

--- a/src/engine_core/rendering/src/RenderGraph/RenderGraphExecutor.cpp
+++ b/src/engine_core/rendering/src/RenderGraph/RenderGraphExecutor.cpp
@@ -13,6 +13,7 @@
 
 #include "RenderGraphExecutor.hpp"
 #include <Assertions.hpp>
+#include <Profiling.hpp>
 #include <algorithm>
 
 using namespace Hush::RenderGraph;
@@ -33,6 +34,7 @@ void RenderGraphExecutor::ResetFrameState()
 
 void RenderGraphExecutor::RealizeResources(RenderGraph &graph)
 {
+	ZoneScoped;
 	graph.GetResourceManager().ForEachResource([&](ResourceId /*id*/, ResourceHandle &handle) {
 		if (!handle.IsRealized())
 		{
@@ -178,6 +180,7 @@ DependencyLevelExecutionContext RenderGraphExecutor::BuildExecutionContext(Rende
 																		   const ResourceManager &resourceManager,
 																		   uint32_t queueCount)
 {
+	ZoneScoped;
 	DependencyLevelExecutionContext execCtx;
 	execCtx.queuePlans.resize(queueCount);
 
@@ -484,6 +487,7 @@ void RenderGraphExecutor::BuildBatchesForIndependentQueue(QueueExecutionPlan &pl
 
 void RenderGraphExecutor::Execute(RenderGraph &graph)
 {
+	ZoneScoped;
 	HUSH_ASSERT(graph.IsCompiled(), "Cannot execute a dirty render graph! Call Compile() first.");
 	HUSH_ASSERT(m_device != nullptr, "Graphics device cannot be null!");
 

--- a/src/engine_core/rendering/src/Systems/RenderGraphSystem.cpp
+++ b/src/engine_core/rendering/src/Systems/RenderGraphSystem.cpp
@@ -6,6 +6,7 @@
 #include "RenderGraphSystem.hpp"
 #include "Components/RenderGraphBuilderComponent.hpp"
 #include "Logger.hpp"
+#include "Profiling.hpp"
 #include "Scene.hpp"
 
 Hush::Graphics::RenderGraphSystem::RenderGraphSystem(Hush::Scene &scene, RenderGraph::RenderDevice *renderDevice)
@@ -41,7 +42,12 @@ void Hush::Graphics::RenderGraphSystem::OnFixedUpdate([[maybe_unused]] float del
 
 void Hush::Graphics::RenderGraphSystem::OnPreRender()
 {
-	m_renderDevice->BeginFrame();
+	ZoneScoped;
+
+	{
+		ZoneScopedN("BeginFrame");
+		m_renderDevice->BeginFrame();
+	}
 	m_frameActive = true;
 
 	auto &renderGraph = m_renderDevice->GetRenderGraph();
@@ -66,6 +72,7 @@ void Hush::Graphics::RenderGraphSystem::OnPreRender()
 		// --------------------------------------------------------------
 		// FAST PATH — graph topology is unchanged, skip recompilation.
 		// --------------------------------------------------------------
+		ZoneScopedN("RenderGraph::FastPath");
 
 		// Reset only the executor's per-frame state (fence counters,
 		// resource state tracker). Graph passes and compilation are kept.
@@ -81,6 +88,8 @@ void Hush::Graphics::RenderGraphSystem::OnPreRender()
 		// Clear the previous frame's render graph (passes, resources,
 		// compilation state) and reset the executor's per-frame state.
 		// Fence objects themselves are kept alive and reused across frames.
+		ZoneScopedN("RenderGraph::FullRebuild");
+
 		m_renderDevice->Reset();
 
 		// Iterate every RenderGraphBuilderComponent entity and invoke its
@@ -103,6 +112,7 @@ void Hush::Graphics::RenderGraphSystem::OnPreRender()
 
 void Hush::Graphics::RenderGraphSystem::OnRender()
 {
+	ZoneScoped;
 	if (!m_renderDevice->IsCompiled())
 	{
 		Hush::LogWarn("RenderGraphSystem::OnRender — graph is not compiled, "

--- a/src/engine_core/rendering/src/WebGPU/WebGPUBindGroup.cpp
+++ b/src/engine_core/rendering/src/WebGPU/WebGPUBindGroup.cpp
@@ -8,6 +8,7 @@
 #include "WebGPUBuffer.hpp"
 #include "WebGPUSampler.hpp"
 #include "WebGPUTexture.hpp"
+#include "Profiling.hpp"
 #include <vector>
 
 namespace Hush::Graphics
@@ -16,6 +17,7 @@ namespace Hush::Graphics
 		: m_entryCount(static_cast<uint32_t>(descriptor.entries.size())),
 		  m_debugName(descriptor.debugName)
 	{
+		ZoneScoped;
 		if (device == nullptr)
 		{
 			return;
@@ -105,6 +107,7 @@ namespace Hush::Graphics
 		: m_layout(descriptor.layout),
 		  m_debugName(descriptor.debugName)
 	{
+		ZoneScoped;
 		if (device == nullptr || descriptor.layout == nullptr)
 		{
 			return;

--- a/src/engine_core/rendering/src/WebGPU/WebGPUBuffer.cpp
+++ b/src/engine_core/rendering/src/WebGPU/WebGPUBuffer.cpp
@@ -7,6 +7,7 @@
 #include "WebGPU/WebGPUGraphicsDevice.hpp"
 #include "webgpu/webgpu-raii.hpp"
 #include "Logger.hpp"
+#include "Profiling.hpp"
 #include <webgpu.h>
 #include <webgpu/webgpu.hpp>
 
@@ -31,6 +32,7 @@ namespace Hush::Graphics
 
 	void *WebGPUBuffer::Map(Graphics::IGraphicsDevice *device)
 	{
+		ZoneScoped;
 		if (m_mappedData != nullptr)
 		{
 			return m_mappedData;

--- a/src/engine_core/rendering/src/WebGPU/WebGPUCommandList.cpp
+++ b/src/engine_core/rendering/src/WebGPU/WebGPUCommandList.cpp
@@ -9,6 +9,7 @@
 #include "WebGPUPipeline.hpp"
 #include "WebGPUBindGroup.hpp"
 #include "Assertions.hpp"
+#include "Profiling.hpp"
 #include <webgpu/webgpu.hpp>
 
 namespace Hush::Graphics
@@ -100,6 +101,7 @@ namespace Hush::Graphics
 
 	void WebGPUCopyCommandList::Reset()
 	{
+		ZoneScoped;
 		if (m_isRecording && m_encoder != nullptr)
 		{
 			m_encoder.release();
@@ -115,6 +117,7 @@ namespace Hush::Graphics
 
 	void WebGPUCopyCommandList::Close()
 	{
+		ZoneScoped;
 		if (!m_isRecording)
 		{
 			return;
@@ -156,6 +159,7 @@ namespace Hush::Graphics
 	void WebGPUCopyCommandList::CopyBuffer(IGraphicsBuffer *src, uint64_t srcOffset, IGraphicsBuffer *dst,
 										   uint64_t dstOffset, uint64_t size)
 	{
+		ZoneScoped;
 		HUSH_ASSERT(m_isRecording, "Command list must be recording");
 		HUSH_ASSERT(src && dst, "Source and destination buffers must be valid");
 
@@ -169,6 +173,7 @@ namespace Hush::Graphics
 													uint32_t dstX, uint32_t dstY, uint32_t dstZ, uint32_t width,
 													uint32_t height, uint32_t depth, uint32_t rowPitch)
 	{
+		ZoneScoped;
 		HUSH_ASSERT(m_isRecording, "Command list must be recording");
 		HUSH_ASSERT(src && dst, "Source buffer and destination texture must be valid");
 
@@ -196,6 +201,7 @@ namespace Hush::Graphics
 													IGraphicsBuffer *dst, uint64_t dstOffset, uint32_t width,
 													uint32_t height, uint32_t depth)
 	{
+		ZoneScoped;
 		HUSH_ASSERT(m_isRecording, "Command list must be recording");
 		HUSH_ASSERT(src && dst, "Source texture and destination buffer must be valid");
 
@@ -223,6 +229,7 @@ namespace Hush::Graphics
 											IGraphicsTexture *dst, uint32_t dstX, uint32_t dstY, uint32_t dstZ,
 											uint32_t width, uint32_t height, uint32_t depth)
 	{
+		ZoneScoped;
 		HUSH_ASSERT(m_isRecording, "Command list must be recording");
 		HUSH_ASSERT(src && dst, "Source and destination textures must be valid");
 
@@ -266,6 +273,7 @@ namespace Hush::Graphics
 
 	void WebGPUComputeCommandList::Reset()
 	{
+		ZoneScoped;
 		if (m_inComputePass && m_computePass != nullptr)
 		{
 			m_computePass.end();
@@ -287,6 +295,7 @@ namespace Hush::Graphics
 
 	void WebGPUComputeCommandList::Close()
 	{
+		ZoneScoped;
 		if (!m_isRecording)
 		{
 			return;
@@ -430,6 +439,7 @@ namespace Hush::Graphics
 
 	void WebGPUComputeCommandList::Dispatch(uint32_t groupCountX, uint32_t groupCountY, uint32_t groupCountZ)
 	{
+		ZoneScoped;
 		HUSH_ASSERT(m_isRecording, "Command list must be recording");
 
 		// Begin compute pass if not already in one
@@ -446,6 +456,7 @@ namespace Hush::Graphics
 
 	void WebGPUComputeCommandList::DispatchIndirect(IGraphicsBuffer *indirectArgsBuffer, uint64_t offset)
 	{
+		ZoneScoped;
 		HUSH_ASSERT(m_isRecording, "Command list must be recording");
 		HUSH_ASSERT(indirectArgsBuffer, "Indirect args buffer must be valid");
 
@@ -519,6 +530,7 @@ namespace Hush::Graphics
 
 	void WebGPUGraphicsCommandList::Reset()
 	{
+		ZoneScoped;
 		if (m_inRenderPass && m_renderPass != nullptr)
 		{
 			m_renderPass.end();
@@ -546,6 +558,7 @@ namespace Hush::Graphics
 
 	void WebGPUGraphicsCommandList::Close()
 	{
+		ZoneScoped;
 		if (!m_isRecording)
 		{
 			return;
@@ -814,6 +827,7 @@ namespace Hush::Graphics
 
 	void WebGPUGraphicsCommandList::BeginRenderPass(const RenderPassDescriptor &descriptor)
 	{
+		ZoneScoped;
 		HUSH_ASSERT(m_isRecording, "Command list must be recording");
 		HUSH_ASSERT(!m_inRenderPass, "Already in a render pass");
 		HUSH_ASSERT(!m_inComputePass, "Cannot begin render pass during compute pass");

--- a/src/engine_core/rendering/src/WebGPU/WebGPUCommandQueue.cpp
+++ b/src/engine_core/rendering/src/WebGPU/WebGPUCommandQueue.cpp
@@ -7,6 +7,7 @@
 #include "WebGPUCommandList.hpp"
 #include "WebGPUFence.hpp"
 #include "Logger.hpp"
+#include "Profiling.hpp"
 
 namespace Hush::Graphics
 {
@@ -19,6 +20,7 @@ namespace Hush::Graphics
 
 	void WebGPUCommandQueue::Submit(std::span<ICommandList *> commandLists)
 	{
+		ZoneScoped;
 		if (commandLists.empty())
 		{
 			return;
@@ -54,6 +56,7 @@ namespace Hush::Graphics
 
 	void WebGPUCommandQueue::SubmitBatched(const SubmitInfo &submitInfo)
 	{
+		ZoneScoped;
 		// WebGPU has a single queue, so cross-queue GPU waits don't apply.
 		// We honour the contract by performing CPU-side waits on the emulated
 		// fence values so that the render graph executor's ordering invariants

--- a/src/engine_core/rendering/src/WebGPU/WebGPUGraphicsDevice.cpp
+++ b/src/engine_core/rendering/src/WebGPU/WebGPUGraphicsDevice.cpp
@@ -21,6 +21,7 @@
 #include <sdl2webgpu/sdl2webgpu.h>
 #include <magic_enum/magic_enum.hpp>
 #include <webgpu/webgpu.hpp>
+#include "Profiling.hpp"
 
 namespace Hush::Graphics
 {
@@ -28,6 +29,7 @@ namespace Hush::Graphics
 	WebGPUGraphicsDevice::WebGPUGraphicsDevice(void *windowHandle)
 		: m_windowHandle(windowHandle)
 	{
+		ZoneScoped;
 		LogTrace("Initializing WebGPU Graphics Device");
 
 		InitializeInstance();
@@ -181,6 +183,7 @@ namespace Hush::Graphics
 
 	std::unique_ptr<IGraphicsBuffer> WebGPUGraphicsDevice::CreateBuffer(const BufferDescriptor &descriptor)
 	{
+		ZoneScoped;
 		wgpu::BufferDescriptor desc{};
 		desc.size = descriptor.size;
 		desc.usage = ConvertBufferUsage(descriptor.usage);
@@ -234,6 +237,7 @@ namespace Hush::Graphics
 
 	std::unique_ptr<IGraphicsTexture> WebGPUGraphicsDevice::CreateTexture(const TextureDescriptor &descriptor)
 	{
+		ZoneScoped;
 		wgpu::TextureDescriptor desc{};
 		desc.size.width = descriptor.width;
 		desc.size.height = descriptor.height;
@@ -283,6 +287,7 @@ namespace Hush::Graphics
 
 	std::unique_ptr<IShaderModule> WebGPUGraphicsDevice::CreateShaderModule(const ShaderModuleDescriptor &descriptor)
 	{
+		ZoneScoped;
 		auto module = std::make_unique<WebGPUShaderModule>(m_device, descriptor);
 		if (!module->IsValid())
 		{
@@ -295,6 +300,7 @@ namespace Hush::Graphics
 	std::unique_ptr<IGraphicsPipeline> WebGPUGraphicsDevice::CreateGraphicsPipeline(
 		const GraphicsPipelineDescriptor &descriptor)
 	{
+		ZoneScoped;
 		auto pipeline = std::make_unique<WebGPUGraphicsPipeline>(m_device, descriptor);
 		if (!pipeline->IsValid())
 		{
@@ -307,6 +313,7 @@ namespace Hush::Graphics
 	std::unique_ptr<IComputePipeline> WebGPUGraphicsDevice::CreateComputePipeline(
 		const ComputePipelineDescriptor &descriptor)
 	{
+		ZoneScoped;
 		auto pipeline = std::make_unique<WebGPUComputePipeline>(m_device, descriptor);
 		if (!pipeline->IsValid())
 		{
@@ -361,6 +368,7 @@ namespace Hush::Graphics
 
 	void WebGPUGraphicsDevice::BeginFrame()
 	{
+		ZoneScoped;
 		if (m_needsResize)
 		{
 			// Release stale frame texture/view from the previous frame before
@@ -415,6 +423,7 @@ namespace Hush::Graphics
 
 	void WebGPUGraphicsDevice::EndFrame()
 	{
+		ZoneScoped;
 		m_surface.present();
 		m_currentFrameView = nullptr;
 		FlushDeletionQueue();

--- a/src/engine_core/rendering/src/WebGPU/WebGPUPipeline.hpp
+++ b/src/engine_core/rendering/src/WebGPU/WebGPUPipeline.hpp
@@ -11,6 +11,7 @@
 #include "../RHI/IBindGroup.hpp"
 #include "WebGPUShaderModule.hpp"
 #include "WebGPUBindGroup.hpp"
+#include "Profiling.hpp"
 #include <string>
 #include <vector>
 #include <webgpu/webgpu.hpp>
@@ -472,6 +473,7 @@ namespace Hush::Graphics
 		/// @brief Build and create the wgpu::RenderPipeline from the descriptor.
 		void CreatePipeline(wgpu::Device device, const GraphicsPipelineDescriptor &descriptor)
 		{
+			ZoneScoped;
 			if (device == nullptr)
 			{
 				return;
@@ -797,6 +799,7 @@ namespace Hush::Graphics
 		/// @brief Build and create the wgpu::ComputePipeline from the descriptor.
 		void CreatePipeline(wgpu::Device device, const ComputePipelineDescriptor &descriptor)
 		{
+			ZoneScoped;
 			if (device == nullptr)
 			{
 				return;

--- a/src/engine_core/rendering/src/WebGPU/WebGPUSampler.cpp
+++ b/src/engine_core/rendering/src/WebGPU/WebGPUSampler.cpp
@@ -6,12 +6,14 @@
 
 #include "WebGPUSampler.hpp"
 #include "WebGPUPipeline.hpp"
+#include "Profiling.hpp"
 
 namespace Hush::Graphics
 {
 	WebGPUSampler::WebGPUSampler(wgpu::Device device, const SamplerDescriptor &descriptor)
 		: m_descriptor(descriptor)
 	{
+		ZoneScoped;
 		if (device == nullptr)
 		{
 			return;

--- a/src/engine_core/rendering/src/WebGPU/WebGPUShaderModule.hpp
+++ b/src/engine_core/rendering/src/WebGPU/WebGPUShaderModule.hpp
@@ -7,6 +7,7 @@
 
 #include "../RHI/IShaderModule.hpp"
 #include "Logger.hpp"
+#include "Profiling.hpp"
 #include <string>
 #include <webgpu/webgpu.hpp>
 
@@ -101,6 +102,7 @@ namespace Hush::Graphics
 		/// @brief Create the wgpu::ShaderModule from the descriptor's WGSL source.
 		void CreateModule(const ShaderModuleDescriptor &descriptor)
 		{
+			ZoneScoped;
 			if (m_device == nullptr)
 			{
 				return;

--- a/src/engine_core/resources/src/Systems/ResourceUploadSystem.cpp
+++ b/src/engine_core/resources/src/Systems/ResourceUploadSystem.cpp
@@ -7,6 +7,7 @@
 
 #include "ResourceUploadSystem.hpp"
 #include "Assertions.hpp"
+#include "Profiling.hpp"
 #include "Components/GpuUploadComponent.hpp"
 #include "Components/MeshReference.hpp"
 #include "Components/RenderGraphBuilderComponent.hpp"
@@ -97,8 +98,13 @@ void Hush::Renderer::ResourceUploadSystem::OnFixedUpdate([[maybe_unused]] float 
 
 void Hush::Renderer::ResourceUploadSystem::OnPreRender()
 {
+	ZoneScoped;
+
 	void *mapped = nullptr;
-	mapped = m_stagingBuffer->Map(m_renderDevice->GetGraphicsDevice());
+	{
+		ZoneScopedN("MapStagingBuffer");
+		mapped = m_stagingBuffer->Map(m_renderDevice->GetGraphicsDevice());
+	}
 	HUSH_ASSERT(mapped != nullptr, "Failed to map the staging buffer for CPU writes!");
 
 	// First half → meshes
@@ -120,8 +126,14 @@ void Hush::Renderer::ResourceUploadSystem::OnPreRender()
 
 	// CPU-only staging: memcpy dirty data into the mapped buffer and
 	// record pending copy descriptors.  No GPU calls happen here.
-	StageDirtyMeshes();
-	StageDirtyTextures();
+	{
+		ZoneScopedN("StageDirtyMeshes");
+		StageDirtyMeshes();
+	}
+	{
+		ZoneScopedN("StageDirtyTextures");
+		StageDirtyTextures();
+	}
 
 	m_bytesUploadedLastFrame = m_meshStaging.offset + m_textureStaging.offset;
 }

--- a/src/engine_core/src/HushEngine.cpp
+++ b/src/engine_core/src/HushEngine.cpp
@@ -11,8 +11,10 @@
 #include "WindowRenderer.hpp"
 #include "filesystem/CFileSystem/CFileSystem.hpp"
 #include <WindowManager.hpp>
+#include <algorithm>
 #include <cstdint>
 #include <glm/ext/vector_float3.hpp>
+#include "Profiling.hpp"
 #include <glm/trigonometric.hpp>
 #include <imgui/imgui.h>
 
@@ -39,13 +41,25 @@ Hush::HushEngine::~HushEngine()
 	this->Quit();
 }
 
-void Hush::HushEngine::Run()
+void Hush::HushEngine::Run(std::span<const char *> args)
 {
 	// Load the VFS with the default data directory (this is where the engine looks for assets by default, but users can
 	// mount additional directories or archives as needed)
 	this->m_internal->vfs.MountFileSystem<Hush::CFileSystem>("engine_res://", "./");
 
 	this->m_app = LoadApplication(this);
+
+	// Check for --wait-profiler flag
+	if (std::ranges::find_if(args, [](const char *arg) { return std::string_view(arg) == "--wait-profiler"; }) !=
+		args.end())
+	{
+		LogInfo("Waiting for Tracy profiler to connect...");
+		while (!TracyIsConnected)
+		{
+			std::this_thread::sleep_for(std::chrono::milliseconds(100));
+		}
+		LogInfo("Tracy profiler connected!");
+	}
 
 	this->m_isApplicationRunning = true;
 	this->m_internal->windowRenderer =
@@ -66,8 +80,14 @@ void Hush::HushEngine::Run()
 
 	while (this->m_isApplicationRunning)
 	{
+		ZoneScoped;
 		std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
-		this->m_internal->windowRenderer->HandleEvents(&this->m_isApplicationRunning);
+
+		{
+			ZoneScopedN("HandleEvents");
+			this->m_internal->windowRenderer->HandleEvents(&this->m_isApplicationRunning);
+		}
+
 		// TODO: Change this to the window renderer
 		if (!this->m_internal->windowRenderer->IsActive())
 		{
@@ -79,17 +99,34 @@ void Hush::HushEngine::Run()
 
 		const float deltaTime = std::chrono::duration<float>(elapsed).count();
 
-		this->m_app->Update(deltaTime);
+		{
+			ZoneScopedN("Update");
+			this->m_app->Update(deltaTime);
+		}
 
-		this->m_app->OnPreRender();
+		{
+			ZoneScopedN("PreRender");
+			this->m_app->OnPreRender();
+		}
 
-		this->m_app->OnRender(deltaTime);
+		{
+			ZoneScopedN("Render");
+			this->m_app->OnRender(deltaTime);
+		}
 
-		this->m_app->OnPostRender();
+		{
+			ZoneScopedN("PostRender");
+			this->m_app->OnPostRender();
+		}
 
-		this->m_app->DisposeFrame();
+		{
+			ZoneScopedN("DisposeFrame");
+			this->m_app->DisposeFrame();
+		}
+
 		std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
 		elapsed = end - start;
+		FrameMark;
 	}
 }
 

--- a/src/engine_core/src/HushEngine.hpp
+++ b/src/engine_core/src/HushEngine.hpp
@@ -10,6 +10,7 @@
 #include "HushBindings.hpp"
 #include "executors/ThreadPool.hpp"
 
+#include <span>
 #include <string_view>
 
 namespace Hush
@@ -44,7 +45,8 @@ namespace Hush
 		~HushEngine();
 
 		/// Starts running the engine with UI components
-		void Run();
+		/// @param args Command-line arguments passed from main()
+		void Run(std::span<const char *> args = {});
 
 		/// Disposes of the HushEngine
 		void Quit();

--- a/src/engine_core/src/main.cpp
+++ b/src/engine_core/src/main.cpp
@@ -1,10 +1,10 @@
 #include "HushEngine.hpp"
 #include "Scene.hpp"
 
-int main()
+int main(int argc, const char *argv[])
 {
 	Hush::HushEngine engine;
-	engine.Run();
+	engine.Run({argv, static_cast<size_t>(argc)});
 	engine.Quit();
 	return 0;
 }

--- a/src/engine_core/threading/src/executors/ThreadPool.cpp
+++ b/src/engine_core/threading/src/executors/ThreadPool.cpp
@@ -7,6 +7,7 @@
 #include "ThreadPool.hpp"
 #include "threadpool/StealingQueue.hpp"
 #include <Platform.hpp>
+#include <Profiling.hpp>
 #include <random>
 #include <semaphore>
 
@@ -50,20 +51,29 @@ namespace Hush::Threading::Executors
 		WorkerThread(ThreadPool &threadpool, std::barrier<> &startBarrier, int32_t threadAffinity)
 			: m_threadPool(threadpool)
 		{
+			// Build thread/fiber names before launching so they're available via the 'this' pointer.
+			// Stored as members because Tracy requires name strings to remain valid for the
+			// lifetime of the program.
+			if (threadAffinity >= 0)
+			{
+				m_threadName = "WorkerThread-P" + std::to_string(threadAffinity);
+			}
+
 			// Create the worker thread
 			m_thread = std::jthread([this, &startBarrier, threadAffinity](std::stop_token stopToken) {
-				const auto threadId = std::hash<std::thread::id>{}(std::this_thread::get_id());
-				Hush::LogFormat(ELogLevel::Debug, "Worker thread started with ID: {}", threadId);
+				if (m_threadName.empty())
+				{
+					const auto threadId = std::hash<std::thread::id>{}(std::this_thread::get_id());
+					m_threadName = "WorkerThread-" + std::to_string(threadId);
+				}
+				Hush::LogFormat(ELogLevel::Debug, "Worker thread started: {}", m_threadName);
 				G_CURRENT_WORKER_THREAD = this;
 				if (threadAffinity >= 0)
 				{
 					SetCurrentThreadAffinity(threadAffinity);
-					SetCurrentThreadName(("WorkerThread-P" + std::to_string(threadAffinity)).c_str());
 				}
-				else
-				{
-					SetCurrentThreadName(("WorkerThread-" + std::to_string(threadId)).c_str());
-				}
+				SetCurrentThreadName(m_threadName.c_str());
+				tracy::SetThreadName(m_threadName.c_str());
 
 				// Wait until the thread is started
 				startBarrier.arrive_and_wait();
@@ -124,7 +134,6 @@ namespace Hush::Threading::Executors
 					TaskOperation *task = *taskResult;
 					if (task != nullptr)
 					{
-						// We have a task, so we can execute it
 						task->m_awaitingCoroutine.resume();
 					}
 					continue;
@@ -155,7 +164,6 @@ namespace Hush::Threading::Executors
 						auto [task, count] = result.value();
 						if (task != nullptr)
 						{
-							// We have a task, so we can execute it
 							task->m_awaitingCoroutine.resume();
 						}
 
@@ -206,6 +214,7 @@ namespace Hush::Threading::Executors
 
 		std::vector<Stealer<TaskOperation *, WORKER_QUEUE_SIZE>> m_stealers;
 		std::jthread m_thread;
+		std::string m_threadName;
 		Worker<TaskOperation *, WORKER_QUEUE_SIZE> m_workerQueue;
 		ThreadPool &m_threadPool;
 		std::uint32_t m_previousStealIndex{};

--- a/src/engine_core/utils/CMakeLists.txt
+++ b/src/engine_core/utils/CMakeLists.txt
@@ -15,6 +15,10 @@ hush_add_library(
 add_library(Hush::Utils ALIAS HushUtils)
 
 target_link_libraries(HushUtils PUBLIC HushLog outcome::hl)
+if (HUSH_ENABLE_PROFILING)
+    target_link_libraries(HushUtils PUBLIC Tracy::TracyClient)
+    target_compile_definitions(HushUtils PUBLIC HUSH_ENABLE_PROFILING)
+endif()
 
 if (UNIX)
     target_link_libraries(HushUtils PRIVATE dl)

--- a/src/engine_core/utils/src/Profiling.hpp
+++ b/src/engine_core/utils/src/Profiling.hpp
@@ -123,7 +123,9 @@
 // NOLINTNEXTLINE
 namespace tracy
 {
-	void SetThreadName(const char *name);
-}
+	void SetThreadName([[maybe_unused]] const char *name)
+	{
+	}
+} // namespace tracy
 
 #endif

--- a/src/engine_core/utils/src/Profiling.hpp
+++ b/src/engine_core/utils/src/Profiling.hpp
@@ -1,0 +1,129 @@
+/*! \file Profiling.hpp
+	\author Alan Ramirez
+	\date 2026-04-12
+	\brief Tracy profiler integration header
+
+	Include this file to use Tracy profiling macros (ZoneScoped, FrameMark, etc.).
+	Currently, due to vcpkg Tracy package limitations (cannot set TRACY_ENABLE),
+	we define the macros to no-ops when HUSH_ENABLE_PROFILING is OFF at CMake level.
+	This allows us to compile out all profiling code when not needed, without relying on Tracy's internal checks.
+*/
+
+#pragma once
+
+#ifdef HUSH_ENABLE_PROFILING
+#include <tracy/Tracy.hpp>
+#else
+#define ZoneNamed(x, y)
+#define ZoneNamedN(x, y, z)
+#define ZoneNamedC(x, y, z)
+#define ZoneNamedNC(x, y, z, w)
+
+#define ZoneTransient(x, y)
+#define ZoneTransientN(x, y, z)
+
+#define ZoneScoped
+#define ZoneScopedN(x)
+#define ZoneScopedC(x)
+#define ZoneScopedNC(x, y)
+
+#define ZoneText(x, y)
+#define ZoneTextV(x, y, z)
+#define ZoneTextF(x, ...)
+#define ZoneTextVF(x, y, ...)
+#define ZoneName(x, y)
+#define ZoneNameV(x, y, z)
+#define ZoneNameF(x, ...)
+#define ZoneNameVF(x, y, ...)
+#define ZoneColor(x)
+#define ZoneColorV(x, y)
+#define ZoneValue(x)
+#define ZoneValueV(x, y)
+#define ZoneIsActive false
+#define ZoneIsActiveV(x) false
+
+#define FrameMark
+#define FrameMarkNamed(x)
+#define FrameMarkStart(x)
+#define FrameMarkEnd(x)
+
+#define FrameImage(x, y, z, w, a)
+
+#define TracyLockable(type, varname) type varname
+#define TracyLockableN(type, varname, desc) type varname
+#define TracySharedLockable(type, varname) type varname
+#define TracySharedLockableN(type, varname, desc) type varname
+#define LockableBase(type) type
+#define SharedLockableBase(type) type
+#define LockMark(x) (void)x
+#define LockableName(x, y, z)
+
+#define TracyPlot(x, y)
+#define TracyPlotConfig(x, y, z, w, a)
+
+#define TracyMessage(x, y)
+#define TracyMessageL(x)
+#define TracyMessageC(x, y, z)
+#define TracyMessageLC(x, y)
+#define TracyAppInfo(x, y)
+
+#define TracyAlloc(x, y)
+#define TracyFree(x)
+#define TracyMemoryDiscard(x)
+#define TracySecureAlloc(x, y)
+#define TracySecureFree(x)
+#define TracySecureMemoryDiscard(x)
+
+#define TracyAllocN(x, y, z)
+#define TracyFreeN(x, y)
+#define TracySecureAllocN(x, y, z)
+#define TracySecureFreeN(x, y)
+
+#define ZoneNamedS(x, y, z)
+#define ZoneNamedNS(x, y, z, w)
+#define ZoneNamedCS(x, y, z, w)
+#define ZoneNamedNCS(x, y, z, w, a)
+
+#define ZoneTransientS(x, y, z)
+#define ZoneTransientNS(x, y, z, w)
+
+#define ZoneScopedS(x)
+#define ZoneScopedNS(x, y)
+#define ZoneScopedCS(x, y)
+#define ZoneScopedNCS(x, y, z)
+
+#define TracyAllocS(x, y, z)
+#define TracyFreeS(x, y)
+#define TracyMemoryDiscardS(x, y)
+#define TracySecureAllocS(x, y, z)
+#define TracySecureFreeS(x, y)
+#define TracySecureMemoryDiscardS(x, y)
+
+#define TracyAllocNS(x, y, z, w)
+#define TracyFreeNS(x, y, z)
+#define TracySecureAllocNS(x, y, z, w)
+#define TracySecureFreeNS(x, y, z)
+
+#define TracyMessageS(x, y, z)
+#define TracyMessageLS(x, y)
+#define TracyMessageCS(x, y, z, w)
+#define TracyMessageLCS(x, y, z)
+
+#define TracySourceCallbackRegister(x, y)
+#define TracyParameterRegister(x, y)
+#define TracyParameterSetup(x, y, z, w)
+#define TracyIsConnected false
+#define TracyIsStarted false
+#define TracySetProgramName(x)
+
+#define TracyFiberEnter(x)
+#define TracyFiberEnterHint(x, y)
+#define TracyFiberLeave
+
+// NOLINTNEXTLINE
+namespace tracy
+{
+	void SetThreadName(const char *name);
+}
+
+#endif

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -24,6 +24,10 @@
     "volk",
     "vulkan",
     "boost-unordered",
-    "shader-slang"
+    "shader-slang",
+    {
+      "name": "tracy",
+      "features": ["on-demand", "fibers"]
+    }
   ]
 }


### PR DESCRIPTION
- Added tracy profiler support
- Added flag to hush engine to allow waiting for the profiler
- Added profiling to a few functions

## Description

This PR implements tracy profiling into Hush Engin

## Related Issues

Closes #125 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Build / CI
- [ ] Other

## Checklist

- [x] Code compiles without warnings (MSVC + Clang)
- [x] I have formatted my code (`hush-devtool format` / `cargo fmt`)
- [ ] I have added/updated relevant documentation
- [ ] I have added/updated tests (if applicable)
- [x] I have tested my changes locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated optional runtime profiling with an app-start flag to wait for profiler connection.

* **Improvements**
  * Added broad profiling scopes across rendering, resource, and engine loops.
  * Improved thread naming and instrumentation for clearer profiling traces.

* **Changes**
  * Scripting host startup has been disabled by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->