### PR TITLE
feat: Allocator support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
               - '.github/workflows/**'
             engine:
               - 'src/engine_core/**'
+              - 'src/editor/**'
               - 'src/cmake/**'
               - 'cmake/**'
               - 'CMakeLists.txt'

--- a/cmake/program-options.cmake
+++ b/cmake/program-options.cmake
@@ -6,6 +6,13 @@ option(HUSH_ENABLE_DOCS "Enable documentation" ON)
 option(HUSH_ENABLE_PROFILING "Enable Tracy profiler instrumentation" ON)
 option(HUSH_ENABLE_MIMALLOC "Use mimalloc as the process-wide allocator" ON)
 
+# When mimalloc backs global operator new, expose HUSH_USE_MIMALLOC to every module (not just
+# the HushEngine assembly) so headers like the coroutine promise allocator can switch on it —
+# coroutine frames then use global new (= mimalloc) rather than the slower in-house pool.
+if (HUSH_ENABLE_MIMALLOC)
+    add_compile_definitions(HUSH_USE_MIMALLOC=1)
+endif()
+
 if (HUSH_ENABLE_LTO)
     include(CheckIPOSupported)
     check_ipo_supported(RESULT result OUTPUT output)

--- a/examples/example1/src/App.cpp
+++ b/examples/example1/src/App.cpp
@@ -18,7 +18,9 @@
 #include <memory>
 
 // NOLINTBEGIN(*-avoid-c-arrays)
-static constexpr const char *FULLSCREEN_SHADER_SOURCE = R"(
+// A `const char[]` array (not a `const char *`) so it binds to NullTerminatedStringView's
+// literal-array constructor when passed to ShaderCompiler::CompileFromSource.
+static constexpr char FULLSCREEN_SHADER_SOURCE[] = R"(
 struct Uniforms
 {
     float4x4 mvp;

--- a/src/editor/src/systems/RenderingSystem.cpp
+++ b/src/editor/src/systems/RenderingSystem.cpp
@@ -6,6 +6,7 @@
 #include "Components/WorldTransform.hpp"
 #include "HushEngine.hpp"
 #include "Logger.hpp"
+#include "NullTerminatedStringView.hpp"
 #include "Profiling.hpp"
 #include "Query.hpp"
 #include "RHI/GraphicsResources.hpp"
@@ -24,6 +25,8 @@
 #include <glm/ext/quaternion_common.hpp>
 #include <glm/matrix.hpp>
 #include <string_view>
+
+#include "StringAllocation.hpp"
 
 using namespace Hush::Graphics;
 
@@ -102,9 +105,12 @@ void Hush::RenderingSystem::Init()
 	HUSH_ASSERT(shaderCompiler != nullptr,
 				"Shader compiler on engine manager can't be null, check initialization order!");
 
+	NullTerminatedStringView actualPathNT =
+		Hush::MakeNullTerminated(actualPath, this->GetScene().GetFrameScopeMemoryResource());
+
 	shaderCompiler->Initialize();
 	Graphics::ShaderCompilationResult compilationResult = shaderCompiler->CompileFromSource(
-		"", actualPath,
+		NullTerminatedStringView(""), actualPathNT,
 		{{Graphics::EShaderStage::Vertex, "vertMain"}, {Graphics::EShaderStage::Fragment, "fragmentMain"}});
 
 	HUSH_ASSERT(compilationResult.success, "Could not compile grid shader, diagnostics: {}!",

--- a/src/engine_core/CMakeLists.txt
+++ b/src/engine_core/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(log)
 add_subdirectory(renderer)
 add_subdirectory(rendering)
 add_subdirectory(utils)
+add_subdirectory(memory)
 add_subdirectory(scripting)
 add_subdirectory(resources)
 add_subdirectory(filesystem)
@@ -27,6 +28,7 @@ target_link_libraries(HushLibs INTERFACE
         Hush::Threading $<TARGET_OBJECTS:HushThreading>
         Hush::Core $<TARGET_OBJECTS:HushCore>
         Hush::Renderer $<TARGET_OBJECTS:HushRenderer>
+        Hush::Memory $<TARGET_OBJECTS:HushMemory>
 )
 
 add_library(Hush::Libs ALIAS HushLibs)

--- a/src/engine_core/core/CMakeLists.txt
+++ b/src/engine_core/core/CMakeLists.txt
@@ -22,7 +22,7 @@ hush_add_library(
 )
 add_library(Hush::Core ALIAS HushCore)
 
-target_link_libraries(HushCore PUBLIC $<IF:$<TARGET_EXISTS:flecs::flecs>,flecs::flecs,flecs::flecs_static> Hush::Threading Hush::Utils Hush::Log zadeh rapidjson Boost::unordered)
+target_link_libraries(HushCore PUBLIC $<IF:$<TARGET_EXISTS:flecs::flecs>,flecs::flecs,flecs::flecs_static> Hush::Threading Hush::Utils Hush::Log Hush::Memory zadeh rapidjson Boost::unordered)
 
 add_test_target(
         TARGET_NAME HushCoreTest
@@ -32,4 +32,4 @@ add_test_target(
         ENABLE_REFLECTION ON
 )
 
-target_link_libraries(HushCoreTest PRIVATE Hush::Threading)
+target_link_libraries(HushCoreTest PRIVATE Hush::Threading Hush::Memory)

--- a/src/engine_core/core/src/Entity.cpp
+++ b/src/engine_core/core/src/Entity.cpp
@@ -50,9 +50,9 @@ Hush::ComponentRef Hush::Entity::CreateComponentReferenceRaw(EntityId componentI
 	auto *world = static_cast<ecs_world_t *>(m_ownerScene->GetWorld());
 	ecs_ref_t ref = ecs_ref_init_id(world, this->m_entityId, componentId);
 	static_assert(sizeof(ecs_ref_t) <= ECS_REF_SIZE,
-	              "ecs_ref_t no longer fits ComponentRef's internal buffer; bump ECS_REF_SIZE.");
+				  "ecs_ref_t no longer fits ComponentRef's internal buffer; bump ECS_REF_SIZE.");
 	static_assert(alignof(ecs_ref_t) <= ECS_REF_ALIGN,
-	              "ecs_ref_t needs stronger alignment than ECS_REF_ALIGN; bump ECS_REF_ALIGN.");
+				  "ecs_ref_t needs stronger alignment than ECS_REF_ALIGN; bump ECS_REF_ALIGN.");
 
 	ComponentRef publicRef{};
 

--- a/src/engine_core/core/src/Entity.cpp
+++ b/src/engine_core/core/src/Entity.cpp
@@ -49,7 +49,10 @@ Hush::ComponentRef Hush::Entity::CreateComponentReferenceRaw(EntityId componentI
 {
 	auto *world = static_cast<ecs_world_t *>(m_ownerScene->GetWorld());
 	ecs_ref_t ref = ecs_ref_init_id(world, this->m_entityId, componentId);
-	static_assert(sizeof(ecs_ref_t) == ECS_REF_SIZE, "Reference size does not match to our internal usage!");
+	static_assert(sizeof(ecs_ref_t) <= ECS_REF_SIZE,
+	              "ecs_ref_t no longer fits ComponentRef's internal buffer; bump ECS_REF_SIZE.");
+	static_assert(alignof(ecs_ref_t) <= ECS_REF_ALIGN,
+	              "ecs_ref_t needs stronger alignment than ECS_REF_ALIGN; bump ECS_REF_ALIGN.");
 
 	ComponentRef publicRef{};
 

--- a/src/engine_core/core/src/Entity.cpp
+++ b/src/engine_core/core/src/Entity.cpp
@@ -170,7 +170,7 @@ Hush::Entity::EntityId Hush::Entity::InternalRegisterCppComponent(
 	return m_ownerScene->InternalRegisterCppComponent(registerStatus, id, desc);
 }
 
-std::optional<Hush::Entity::EntityId> Hush::Entity::InternalCachedComponentId(const std::string_view name) const
+std::optional<Hush::Entity::EntityId> Hush::Entity::InternalCachedComponentId(const NullTerminatedStringView name) const
 {
 	return m_ownerScene->GetRegisteredComponentId(name);
 }

--- a/src/engine_core/core/src/Entity.hpp
+++ b/src/engine_core/core/src/Entity.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "Assertions.hpp"
+#include "NullTerminatedStringView.hpp"
 #include "traits/EntityTraits.hpp"
 #include "HushBindings.hpp"
 
@@ -342,7 +343,7 @@ namespace Hush
 		/// @param name Name of the component.
 		/// @return Id of the component, or std::nullopt if the component is not found.
 		[[nodiscard]]
-		std::optional<EntityId> InternalCachedComponentId(std::string_view name) const;
+		std::optional<EntityId> InternalCachedComponentId(NullTerminatedStringView name) const;
 
 		/// Id of the entity
 		EntityId m_entityId{};

--- a/src/engine_core/core/src/Entity.hpp
+++ b/src/engine_core/core/src/Entity.hpp
@@ -34,7 +34,10 @@ namespace Hush
 
 	template <typename... Components>
 	class Query;
+	// Upper bound on sizeof(ecs_ref_t): 48 bytes on 64-bit targets. On 32 bit target (such as wasm32) the two trailing
+	// pointers are 4 bytes each, so it is 40 there.
 	constexpr size_t ECS_REF_SIZE = 48;
+	constexpr size_t ECS_REF_ALIGN = 8; // ecs_ref_t holds uint64_t/pointers, so it needs 8-byte alignment.
 
 	class Entity;
 
@@ -62,7 +65,7 @@ namespace Hush
 		uint64_t GetComponentId() const;
 
 	private:
-		mutable std::array<std::byte, ECS_REF_SIZE> m_refInternal;
+		alignas(ECS_REF_ALIGN) mutable std::array<std::byte, ECS_REF_SIZE> m_refInternal;
 		// TODO: Make it a thread local variable
 		void *m_world = nullptr;
 		friend class Entity;

--- a/src/engine_core/core/src/Query.cpp
+++ b/src/engine_core/core/src/Query.cpp
@@ -20,9 +20,9 @@ Hush::RawQuery::RawQuery(Scene *scene, void *query)
 bool Hush::RawQuery::QueryIterator::Next()
 {
 	static_assert(sizeof(ecs_iter_t) <= ECS_ITER_SIZE,
-	              "ecs_iter_t no longer fits QueryIterator's internal buffer; bump ECS_ITER_SIZE.");
+				  "ecs_iter_t no longer fits QueryIterator's internal buffer; bump ECS_ITER_SIZE.");
 	static_assert(alignof(ecs_iter_t) <= ECS_ITER_ALIGNMENT,
-	              "ecs_iter_t needs stronger alignment than ECS_ITER_ALIGNMENT; bump ECS_ITER_ALIGNMENT.");
+				  "ecs_iter_t needs stronger alignment than ECS_ITER_ALIGNMENT; bump ECS_ITER_ALIGNMENT.");
 
 	if (m_hasBeenDestroyed)
 	{

--- a/src/engine_core/core/src/Query.cpp
+++ b/src/engine_core/core/src/Query.cpp
@@ -19,6 +19,11 @@ Hush::RawQuery::RawQuery(Scene *scene, void *query)
 
 bool Hush::RawQuery::QueryIterator::Next()
 {
+	static_assert(sizeof(ecs_iter_t) <= ECS_ITER_SIZE,
+	              "ecs_iter_t no longer fits QueryIterator's internal buffer; bump ECS_ITER_SIZE.");
+	static_assert(alignof(ecs_iter_t) <= ECS_ITER_ALIGNMENT,
+	              "ecs_iter_t needs stronger alignment than ECS_ITER_ALIGNMENT; bump ECS_ITER_ALIGNMENT.");
+
 	if (m_hasBeenDestroyed)
 	{
 		return false;

--- a/src/engine_core/core/src/Scene.cpp
+++ b/src/engine_core/core/src/Scene.cpp
@@ -11,6 +11,8 @@
 #include <flecs.h>
 #include <flecs/addons/flecs_c.h>
 #include "Profiling.hpp"
+#include <memory>
+#include <string>
 
 constexpr std::size_t DEFAULT_SYSTEMS_CAPACITY = 128;
 
@@ -28,7 +30,14 @@ Hush::Scene::Scene(HushEngine *engine, Hush::Threading::Executors::ThreadPool *t
 
 Hush::Scene::~Scene()
 {
+	// ecs_fini runs component binding_ctx_free hooks, which destroy any objects allocated from
+	// the scene arena. Rewind the arena only afterwards, once nothing references it.
 	ecs_fini(static_cast<ecs_world_t *>(m_world));
+
+	if (m_sceneMemory != nullptr)
+	{
+		m_sceneMemory->Reset();
+	}
 }
 
 void Hush::Scene::Init()
@@ -265,10 +274,10 @@ void Hush::Scene::DestroyEntity(Entity &entity)
 	ecs_delete(world, entity.GetId());
 }
 
-std::optional<std::uint64_t> Hush::Scene::GetRegisteredComponentId(std::string_view name)
+std::optional<std::uint64_t> Hush::Scene::GetRegisteredComponentId(NullTerminatedStringView name)
 {
 	std::shared_lock lock(m_registeredEntitiesMutex);
-	const auto entityIt = m_registeredEntities.find(name.data());
+	const auto entityIt = m_registeredEntities.find(std::string(std::string_view(name)));
 
 	if (entityIt != m_registeredEntities.end())
 	{
@@ -279,10 +288,10 @@ std::optional<std::uint64_t> Hush::Scene::GetRegisteredComponentId(std::string_v
 	return std::nullopt;
 }
 
-void Hush::Scene::RegisterComponentId(std::string_view name, Entity::EntityId id)
+void Hush::Scene::RegisterComponentId(NullTerminatedStringView name, Entity::EntityId id)
 {
 	std::unique_lock lock(m_registeredEntitiesMutex);
-	m_registeredEntities.insert_or_assign(name.data(), id);
+	m_registeredEntities.insert_or_assign(std::string(std::string_view(name)), id);
 }
 
 std::optional<Hush::Entity> Hush::Scene::EntityFromId(EntityId id)
@@ -312,16 +321,28 @@ Hush::Entity::EntityId Hush::Scene::RegisterComponentRaw(const ComponentTraits::
 
 		void *userCtx{};
 		void (*userCtxFree)(void *){};
+
+		// The resource this instance was allocated from, so binding_ctx_free can return the
+		// storage symmetrically (a no-op for the scene arena, an actual free for the fallback).
+		std::pmr::memory_resource *ownerResource{};
 	};
 
-	// TODO: Arena
-	auto *componentInfo = new ComponentInfo();
+	// This context lives for the scene/world lifetime, so it belongs in the scene arena. When
+	// the arena is not wired yet, fall back to the general heap; either way the free hook below
+	// routes deallocation back through ownerResource.
+	std::pmr::memory_resource *ownerResource = m_sceneMemory != nullptr
+												   ? static_cast<std::pmr::memory_resource *>(m_sceneMemory)
+												   : std::pmr::new_delete_resource();
+
+	void *storage = ownerResource->allocate(sizeof(ComponentInfo), alignof(ComponentInfo));
+	auto *componentInfo = std::construct_at(static_cast<ComponentInfo *>(storage));
 	componentInfo->size = desc.size;
 	componentInfo->alignment = desc.alignment;
 	componentInfo->name = desc.name;
 	componentInfo->ops = desc.ops;
 	componentInfo->userCtx = desc.userCtx;
 	componentInfo->userCtxFree = desc.userCtxFree;
+	componentInfo->ownerResource = ownerResource;
 
 	ecs_component_desc_t componentDesc = {};
 	ecs_entity_desc_t associatedEntityDesc = {};
@@ -337,12 +358,14 @@ Hush::Entity::EntityId Hush::Scene::RegisterComponentRaw(const ComponentTraits::
 	componentDesc.entity = ecs_entity_init(world, &associatedEntityDesc);
 
 	componentDesc.type.hooks.binding_ctx_free = [](void *ctx) {
-		const auto *info = static_cast<ComponentInfo *>(ctx);
+		auto *info = static_cast<ComponentInfo *>(ctx);
 		if (info->userCtxFree != nullptr)
 		{
 			info->userCtxFree(info->userCtx);
 		}
-		delete info;
+		std::pmr::memory_resource *ownerResource = info->ownerResource;
+		std::destroy_at(info);
+		ownerResource->deallocate(info, sizeof(ComponentInfo), alignof(ComponentInfo));
 	};
 
 	if (desc.ops.ctor != nullptr)
@@ -512,11 +535,10 @@ Hush::Entity::EntityId Hush::Scene::RegisterComponentRaw(const ComponentTraits::
 	return componentId;
 }
 
-Hush::Entity::EntityId Hush::Scene::Lookup(std::string_view tag) const
+Hush::Entity::EntityId Hush::Scene::Lookup(NullTerminatedStringView tag) const
 {
 	auto *world = static_cast<ecs_world_t *>(this->m_world);
-	Entity::EntityId result = ecs_lookup(world, tag.data());
-	return result;
+	return ecs_lookup(world, tag.c_str());
 }
 
 Hush::RawQuery Hush::Scene::CreateRawQuery(std::span<Entity::EntityId> components, RawQuery::ECacheMode cacheMode)
@@ -545,8 +567,13 @@ Hush::Entity::EntityId Hush::Scene::InternalRegisterCppComponent(
 	// has never been registered.
 	if (registerStatus == ComponentTraits::detail::EEntityRegisterStatus::NotRegistered)
 	{
+		// desc.name is a null-terminated C string (from GetTypeName<T>()), but a plain const
+		// char* does not implicitly convert to NullTerminatedStringView, so wrap it explicitly.
+		const NullTerminatedStringView componentName =
+			NullTerminatedStringView::promise_null_terminated(std::string_view{desc.name});
+
 		// First, check if the component is already registered in the scene.
-		if (auto cachedComponentId = GetRegisteredComponentId(desc.name); cachedComponentId.has_value())
+		if (auto cachedComponentId = GetRegisteredComponentId(componentName); cachedComponentId.has_value())
 		{
 			// Okay, already registered in the scene by another thread or translation unit.
 			*id = *cachedComponentId;
@@ -555,7 +582,7 @@ Hush::Entity::EntityId Hush::Scene::InternalRegisterCppComponent(
 		{
 			// We need to register the component.
 			*id = RegisterComponentRaw(desc);
-			RegisterComponentId(desc.name, *id);
+			RegisterComponentId(componentName, *id);
 		}
 	}
 	return *id;

--- a/src/engine_core/core/src/Scene.cpp
+++ b/src/engine_core/core/src/Scene.cpp
@@ -449,6 +449,7 @@ Hush::Entity::EntityId Hush::Scene::RegisterComponentRaw(const ComponentTraits::
 	componentInfo->userCtx = desc.userCtx;
 	componentInfo->userCtxFree = desc.userCtxFree;
 	componentInfo->ownerResource = ownerResource;
+	componentInfo->opsFlags = desc.opsFlags;
 
 	ecs_component_desc_t componentDesc = {};
 	ecs_entity_desc_t associatedEntityDesc = {};

--- a/src/engine_core/core/src/Scene.hpp
+++ b/src/engine_core/core/src/Scene.hpp
@@ -8,8 +8,10 @@
 
 #include "Assertions.hpp"
 #include "Entity.hpp"
+#include "Hush/Memory/ThreadLocalMemoryResourcePool.hpp"
 #include "ISystem.hpp"
 #include "Logger.hpp"
+#include "NullTerminatedStringView.hpp"
 #include "Query.hpp"
 #include "HushBindings.hpp"
 #include "QueryBuilder.hpp"
@@ -20,6 +22,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <memory_resource>
 #include <shared_mutex>
 #include <string>
 #include <unordered_map>
@@ -177,13 +180,14 @@ namespace Hush
 		/// Get the component registered id by name
 		/// @param name Component name
 		/// @return The component id if it exists, std::nullopt otherwise
-		std::optional<std::uint64_t> GetRegisteredComponentId(std::string_view name);
+		std::optional<std::uint64_t> GetRegisteredComponentId(NullTerminatedStringView name);
 
 		/// Register a component id
 		/// @param name Name of the component
 		/// @param id Id of the component
-		[[hush::export]]
-		void RegisterComponentId(std::string_view name, Entity::EntityId id);
+		// NOTE: not [[hush::export]] — the binding generator can't yet marshal
+		// NullTerminatedStringView (Hush-Engine/hush-llvm#8). Re-export once supported.
+		void RegisterComponentId(NullTerminatedStringView name, Entity::EntityId id);
 
 		std::optional<Entity> EntityFromId(EntityId id);
 
@@ -193,8 +197,10 @@ namespace Hush
 		[[nodiscard]] [[hush::export]]
 		EntityId RegisterComponentRaw(const ComponentTraits::ComponentInfo &desc) const;
 
-		[[nodiscard]] [[hush::export]]
-		EntityId Lookup(std::string_view tag) const;
+		// NOTE: not [[hush::export]] — the binding generator can't yet marshal
+		// NullTerminatedStringView (Hush-Engine/hush-llvm#8). Re-export once supported.
+		[[nodiscard]]
+		EntityId Lookup(NullTerminatedStringView tag) const;
 
 		template <typename... Components>
 		Query<Components...> CreateQuery(RawQuery::ECacheMode cacheMode = RawQuery::ECacheMode::Default)
@@ -241,6 +247,25 @@ namespace Hush
 		const HushEngine *GetEngine() const
 		{
 			return this->m_engine;
+		}
+
+		/// Sets the engine-owned frame and scene-scoped memory resources into this scene.
+		/// Both may be null, in which case the scene falls back to owning heap allocations.
+		void SetMemoryResources(std::pmr::memory_resource *frameMemory,
+								Hush::Memory::ThreadLocalMemoryResourcePool *sceneMemory) noexcept
+		{
+			this->m_frameMemory = frameMemory;
+			this->m_sceneMemory = sceneMemory;
+		}
+
+		/// The engine-owned frame-scoped memory resource wired into this scene, or null if not
+		/// wired. Handy for callers that only hold a `Scene*` and need to materialize a
+		/// `NullTerminatedStringView` from a bare view before calling `Lookup` and friends, e.g.
+		/// `scene->Lookup(MakeNullTerminated(tag, scene->GetFrameScopeMemoryResource()))`.
+		[[nodiscard]]
+		std::pmr::memory_resource *GetFrameScopeMemoryResource() const noexcept
+		{
+			return this->m_frameMemory;
 		}
 
 		[[nodiscard]]
@@ -311,6 +336,14 @@ namespace Hush
 		std::vector<uintptr_t> m_scriptingSystems;
 
 		HushEngine *m_engine;
+
+		/// Frame-scoped memory resource (owned by the engine): transient allocations such as
+		/// null-terminated string copies at C-API boundaries. Null until wired by the engine.
+		std::pmr::memory_resource *m_frameMemory = nullptr;
+
+		/// Scene-scoped bump allocator (owned by the engine). Allocations live until the scene
+		/// is torn down, at which point ~Scene rewinds it. Null until wired by the engine.
+		Hush::Memory::ThreadLocalMemoryResourcePool *m_sceneMemory = nullptr;
 
 		/// Thread pool used by the scene for parallel operations
 		Threading::Executors::ThreadPool *m_threadPool;

--- a/src/engine_core/memory/CMakeLists.txt
+++ b/src/engine_core/memory/CMakeLists.txt
@@ -1,0 +1,34 @@
+# Memory support subproject
+
+hush_add_library(
+        TARGET_NAME HushMemory
+        LIB_TYPE OBJECT
+        SRCS src/Hush/Memory/ThreadLocalMemoryResourcePool.cpp
+             src/Hush/Memory/CoroutineFrameResource.cpp
+        PUBLIC_HEADER_DIRS src
+)
+add_library(Hush::Memory ALIAS HushMemory)
+
+target_link_libraries(HushMemory PUBLIC Hush::Log Hush::Utils)
+
+add_test_target(
+        TARGET_NAME HushMemoryTest
+        ENGINE_TARGET HushMemory
+        SRCS tests/ThreadLocalMemoryResourcePool.test.cpp
+             tests/CoroutineFrameResource.test.cpp
+             tests/MakeNullTerminated.test.cpp
+             tests/AllocatorBenchmark.test.cpp
+        HEADER_DIRS tests
+)
+
+# Link mimalloc into the benchmark so AllocatorBenchmark can compare the coroutine pool against
+# mimalloc directly (the real baseline: un-pooled coroutine frames hit mimalloc via the global
+# operator new override). The test executable itself is not minject'd, so ::operator new is CRT
+# malloc — mi_malloc/mi_free give the apples-to-apples number. Gated on mimalloc being available
+# (it always is via vcpkg on non-emscripten), independent of the engine's HUSH_ENABLE_MIMALLOC.
+find_package(mimalloc CONFIG QUIET)
+if (TARGET mimalloc OR TARGET mimalloc-static)
+    target_link_libraries(HushMemoryTest PRIVATE
+            $<IF:$<TARGET_EXISTS:mimalloc-static>,mimalloc-static,mimalloc>)
+    target_compile_definitions(HushMemoryTest PRIVATE HUSH_USE_MIMALLOC=1)
+endif()

--- a/src/engine_core/memory/src/Hush/Memory/CoroutineFrameResource.cpp
+++ b/src/engine_core/memory/src/Hush/Memory/CoroutineFrameResource.cpp
@@ -1,0 +1,241 @@
+/*! \file CoroutineFrameResource.cpp
+	\author Alan Ramirez Herrera
+	\date 2026-07-01
+	\brief Thread-sharded free-list backing the coroutine frame memory resource.
+
+	Each thread owns a shard of size-classed free-lists. Same-thread allocate/deallocate is
+	lock- and atomic-free (the common ParallelFor case: a frame allocated and freed on the same
+	worker). A frame freed by a different thread than allocated it is pushed onto the owning
+	shard's atomic MPSC "foreign free" list, which the owner reclaims in one swap when it next
+	needs a block of that size class. Shards and slabs are intentionally leaked (process
+	lifetime), so a frame freed after its allocating thread exits is still valid.
+*/
+
+#include "Hush/Memory/CoroutineFrameResource.hpp"
+
+#include <array>
+#include <atomic>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+
+namespace Hush::Memory
+{
+	namespace
+	{
+		// The alignment we serve. The payload sits HEADER_SIZE bytes after the block start,
+		// which holds the header (when allocated) or the free-list node (when free).
+		constexpr std::size_t ALIGNMENT = __STDCPP_DEFAULT_NEW_ALIGNMENT__;
+
+		// Size classes are TOTAL block sizes (header + payload). In an optimized build
+		// the hot Task/ParallelFor/WhenAll frames are ~96/128/160 B of payload (~112/144/176 B
+		// total, >99.9% of allocations), so the classes are dense at 128/160/192 (each hot total
+		// rounds up only ~16 B) and coarse away from there. Rare tiny/large frames tolerate the
+		// extra rounding, per the "prioritize the common sizes" trade-off. Every size is a
+		// multiple of ALIGNMENT so cells carved from an aligned slab stay aligned.
+		constexpr std::size_t CELL_SIZES[] = {32, 64, 128, 160, 192, 256, 384, 512, 1024};
+		constexpr int NUM_SIZE_CLASSES = static_cast<int>(sizeof(CELL_SIZES) / sizeof(CELL_SIZES[0]));
+		constexpr std::size_t MAX_CELL = CELL_SIZES[NUM_SIZE_CLASSES - 1];
+
+		// O(1) size->class map: a table over [0, MAX_CELL] at ALIGNMENT granularity. Bucket
+		// b = totals in (b*ALIGNMENT, (b+1)*ALIGNMENT]; CLASS_TABLE[b] is the smallest class whose
+		// cell fits that bucket's largest total. Works for arbitrary (non-power-of-two) classes.
+		constexpr int NUM_BUCKETS = static_cast<int>(MAX_CELL / ALIGNMENT);
+		constexpr std::array<std::uint8_t, static_cast<std::size_t>(NUM_BUCKETS)> BuildClassTable()
+		{
+			std::array<std::uint8_t, static_cast<std::size_t>(NUM_BUCKETS)> table{};
+			for (int b = 0; b < NUM_BUCKETS; ++b)
+			{
+				const std::size_t target = static_cast<std::size_t>(b + 1) * ALIGNMENT;
+				int cls = 0;
+				while (cls < NUM_SIZE_CLASSES && CELL_SIZES[cls] < target)
+				{
+					++cls;
+				}
+				table[static_cast<std::size_t>(b)] = static_cast<std::uint8_t>(cls);
+			}
+			return table;
+		}
+		constexpr auto CLASS_TABLE = BuildClassTable();
+
+		static_assert(CELL_SIZES[0] % ALIGNMENT == 0);
+		static_assert(MAX_CELL % ALIGNMENT == 0);
+
+		constexpr std::size_t SLAB_BYTES = std::size_t{64} * 1024; // upstream request per refill
+		constexpr std::size_t MIN_SLAB_CELLS = 8;
+
+		constexpr std::size_t AlignUp(std::size_t n, std::size_t a) noexcept
+		{
+			return (n + a - 1) & ~(a - 1);
+		}
+
+		struct FreeNode
+		{
+			FreeNode *next;
+		};
+
+		struct Shard
+		{
+			FreeNode *localFree[NUM_SIZE_CLASSES] = {};					// owning thread only
+			std::atomic<FreeNode *> foreignFree[NUM_SIZE_CLASSES] = {}; // pushed by other threads (MPSC)
+		};
+
+		// Header prepended to every allocation. `owner == nullptr` marks a large block that came
+		// straight from upstream; otherwise the block belongs to `owner`'s free-list `classIndex`.
+		struct BlockHeader
+		{
+			Shard *owner;
+			std::uint32_t classIndex;
+			std::uint32_t blockSize; // total bytes handed to upstream (large blocks only)
+		};
+
+		// Rounded up so the payload (block + HEADER_SIZE) keeps ALIGNMENT.
+		constexpr std::size_t HEADER_SIZE = AlignUp(sizeof(BlockHeader), ALIGNMENT);
+
+		static_assert(sizeof(FreeNode) <= HEADER_SIZE);
+		static_assert(CELL_SIZES[0] >= HEADER_SIZE);
+
+		// Smallest class whose cell fits `totalBytes`, or -1 if it exceeds MAX_CELL (-> upstream).
+		// O(1) table lookup.
+		int SizeClassIndex(std::size_t totalBytes) noexcept
+		{
+			if (totalBytes > MAX_CELL)
+			{
+				return -1;
+			}
+			return CLASS_TABLE[(totalBytes - 1) / ALIGNMENT];
+		}
+
+		// The calling thread's shard pointer (null until first allocation on this thread). The
+		// pointed-to Shard is heap-allocated and leaked, so it outlives the thread — foreign
+		// frees remain valid after the allocating thread exits.
+		Shard *&LocalShardSlot() noexcept
+		{
+			thread_local Shard *shard = nullptr;
+			return shard;
+		}
+
+		Shard &LocalShard()
+		{
+			Shard *&slot = LocalShardSlot();
+			if (slot == nullptr)
+			{
+				slot = new Shard();
+			}
+			return *slot;
+		}
+
+		/// The coroutine-frame resource: a thin `memory_resource` over the thread-sharded pools.
+		class ShardedCoroutineResource final : public std::pmr::memory_resource
+		{
+		public:
+			explicit ShardedCoroutineResource(std::pmr::memory_resource *upstream) noexcept
+				: m_upstream(upstream)
+			{
+			}
+
+		protected:
+			void *do_allocate(std::size_t bytes, std::size_t alignment) override
+			{
+				// Coroutine frames never over-align; keep the header scheme simple.
+				assert(alignment <= ALIGNMENT);
+				(void)alignment;
+
+				const std::size_t total = HEADER_SIZE + bytes;
+				const int sc = SizeClassIndex(total);
+				if (sc < 0)
+				{
+					// Too big to pool: prefix a header and hand the rest back from upstream.
+					const std::size_t blockSize = AlignUp(total, ALIGNMENT);
+					void *base = m_upstream->allocate(blockSize, ALIGNMENT);
+					::new (base) BlockHeader{nullptr, 0U, static_cast<std::uint32_t>(blockSize)};
+					return static_cast<std::byte *>(base) + HEADER_SIZE;
+				}
+
+				Shard &shard = LocalShard();
+				if (shard.localFree[sc] == nullptr)
+				{
+					// Reclaim everything other threads freed for this class in one swap...
+					shard.localFree[sc] = shard.foreignFree[sc].exchange(nullptr, std::memory_order_acquire);
+					if (shard.localFree[sc] == nullptr)
+					{
+						// ...still empty: carve a fresh slab.
+						RefillFromSlab(shard, sc);
+					}
+				}
+
+				FreeNode *node = shard.localFree[sc];
+				shard.localFree[sc] = node->next;
+				::new (node)
+					BlockHeader{&shard, static_cast<std::uint32_t>(sc), static_cast<std::uint32_t>(CELL_SIZES[sc])};
+				return reinterpret_cast<std::byte *>(node) + HEADER_SIZE;
+			}
+
+			void do_deallocate(void *ptr, std::size_t /*bytes*/, std::size_t /*alignment*/) noexcept override
+			{
+				auto *header = reinterpret_cast<BlockHeader *>(static_cast<std::byte *>(ptr) - HEADER_SIZE);
+				Shard *owner = header->owner;
+				if (owner == nullptr)
+				{
+					m_upstream->deallocate(header, header->blockSize, ALIGNMENT);
+					return;
+				}
+
+				const std::uint32_t sc = header->classIndex;
+				auto *node = reinterpret_cast<FreeNode *>(header); // reuse the block as a free node
+
+				if (owner == LocalShardSlot())
+				{
+					// Same-thread free: no atomics.
+					node->next = owner->localFree[sc];
+					owner->localFree[sc] = node;
+				}
+				else
+				{
+					// Cross-thread free: push onto the owner's MPSC foreign list.
+					FreeNode *head = owner->foreignFree[sc].load(std::memory_order_relaxed);
+					do
+					{
+						node->next = head;
+					} while (!owner->foreignFree[sc].compare_exchange_weak(head, node, std::memory_order_release,
+																		   std::memory_order_relaxed));
+				}
+			}
+
+			[[nodiscard]]
+			bool do_is_equal(const std::pmr::memory_resource &other) const noexcept override
+			{
+				return this == &other;
+			}
+
+		private:
+			void RefillFromSlab(Shard &shard, int sc)
+			{
+				const std::size_t cell = CELL_SIZES[sc];
+				std::size_t cells = SLAB_BYTES / cell;
+				if (cells < MIN_SLAB_CELLS)
+				{
+					cells = MIN_SLAB_CELLS;
+				}
+				auto *slab = static_cast<std::byte *>(m_upstream->allocate(cell * cells, ALIGNMENT));
+				for (std::size_t i = 0; i < cells; ++i)
+				{
+					auto *node = reinterpret_cast<FreeNode *>(slab + i * cell);
+					node->next = shard.localFree[sc];
+					shard.localFree[sc] = node;
+				}
+				// The slab is intentionally leaked (process lifetime).
+			}
+
+			std::pmr::memory_resource *m_upstream;
+		};
+	} // namespace
+
+	std::pmr::memory_resource *CoroutineFrameResource() noexcept
+	{
+		// Leaked singleton: coroutine operator new/delete may run during static de-initialization,
+		// so the resource (and every shard/slab it owns) must live for the whole process.
+		static auto *resource = new ShardedCoroutineResource(std::pmr::new_delete_resource());
+		return resource;
+	}
+} // namespace Hush::Memory

--- a/src/engine_core/memory/src/Hush/Memory/CoroutineFrameResource.hpp
+++ b/src/engine_core/memory/src/Hush/Memory/CoroutineFrameResource.hpp
@@ -1,0 +1,67 @@
+/*! \file CoroutineFrameResource.hpp
+	\author Alan Ramirez Herrera
+	\date 2026-07-01
+	\brief Process-wide, cross-thread-safe memory resource for coroutine frame allocations,
+		   plus a helper macro to route a promise type's operator new/delete through it.
+*/
+
+#pragma once
+
+#include <cstddef>
+#include <memory_resource>
+#include <new>
+
+namespace Hush::Memory
+{
+	/// Returns the process-wide memory resource used for coroutine frame allocations.
+	///
+	/// Coroutine frames are allocated and freed *individually*, and — because the engine's
+	/// thread pool is work-stealing — a frame allocated on one thread may be destroyed on a
+	/// different thread (e.g. a detached `SelfDeleteTask` that self-destroys in
+	/// `final_suspend`). The returned resource is therefore safe for concurrent, cross-thread
+	/// allocate/deallocate.
+	///
+	/// ## Implementation (thread-sharded free-list — the mimalloc pattern)
+	/// Each thread gets its own shard of size-classed free-lists. Same-thread `allocate`/
+	/// `deallocate` hit those free-lists with **no atomics** (the hot path for the synchronous
+	/// `ParallelFor` fan-out, where a frame is allocated and freed on the same worker). A frame
+	/// freed by a *different* thread than allocated it is pushed onto the owning shard's atomic
+	/// MPSC "foreign free" list; the owner reclaims that list in a single atomic swap the next
+	/// time it needs a block of that size class. Shards and their slabs are intentionally leaked
+	/// (process lifetime), so a frame freed after its allocating thread exits is still valid.
+	///
+	/// @note Optimized for the coroutine-frame use case: alignment up to `max_align_t`. Requests
+	///       whose payload exceeds the largest size class fall back to the upstream resource
+	///       (`new_delete` -> mimalloc). Over-aligned requests are not expected from coroutine
+	///       frames and are asserted against in debug.
+	[[nodiscard]]
+	std::pmr::memory_resource *CoroutineFrameResource() noexcept;
+} // namespace Hush::Memory
+
+/// Injects a coroutine-frame `operator new`/`operator delete` pair into a promise type,
+/// routing frame allocations through `Hush::Memory::CoroutineFrameResource()`.
+///
+/// The C++ coroutine machinery calls the *sized* `operator delete` with the same size it
+/// passed to `operator new`, so the pointer/size/alignment triple always round-trips
+/// correctly through the pmr resource. Place this inside the body of every promise type
+/// whose frames should be pooled.
+///
+/// **Conditional:** when `HUSH_USE_MIMALLOC` is defined, mimalloc already backs the global
+/// `operator new` and — measured — is faster than this pool at real coroutine frame sizes, so
+/// the macro expands to nothing and frames use global `operator new` (= mimalloc) directly. The
+/// pool is used only where mimalloc is absent (e.g. Emscripten), where it beats the default
+/// allocator. See AllocatorBenchmark for the numbers.
+#if defined(HUSH_USE_MIMALLOC)
+#define HUSH_COROUTINE_FRAME_ALLOCATOR()
+#else
+#define HUSH_COROUTINE_FRAME_ALLOCATOR()                                                                               \
+	static void *operator new(std::size_t hushFrameSize)                                                               \
+	{                                                                                                                  \
+		return ::Hush::Memory::CoroutineFrameResource()->allocate(hushFrameSize, __STDCPP_DEFAULT_NEW_ALIGNMENT__);    \
+	}                                                                                                                  \
+	static void operator delete(void *hushFramePtr, std::size_t hushFrameSize) noexcept                                \
+	{                                                                                                                  \
+		::Hush::Memory::CoroutineFrameResource()->deallocate(hushFramePtr, hushFrameSize,                              \
+															 __STDCPP_DEFAULT_NEW_ALIGNMENT__);                        \
+	}
+#endif

--- a/src/engine_core/memory/src/Hush/Memory/ThreadLocalMemoryResourcePool.cpp
+++ b/src/engine_core/memory/src/Hush/Memory/ThreadLocalMemoryResourcePool.cpp
@@ -1,0 +1,131 @@
+/*! \file ThreadLocalMemoryResourcePool.cpp
+	\author Alan Ramirez Herrera
+	\date 2026-07-01
+	\brief Implementation of ThreadLocalMemoryResourcePool.
+*/
+
+#include "Hush/Memory/ThreadLocalMemoryResourcePool.hpp"
+
+#include <atomic>
+#include <cstdint>
+#include <unordered_map>
+
+namespace Hush::Memory
+{
+	namespace
+	{
+		// Hands out a unique, never-reused id per pool instance (see m_generation).
+		std::atomic<std::uint64_t> g_generationCounter{1};
+	} // namespace
+
+	ThreadLocalMemoryResourcePool::ThreadLocalMemoryResourcePool(std::size_t initialArenaSize,
+																 std::pmr::memory_resource *upstream) noexcept
+		: m_generation(g_generationCounter.fetch_add(1, std::memory_order_relaxed)),
+		  m_initialArenaSize(initialArenaSize),
+		  m_upstream(upstream),
+		  m_countingUpstream(upstream)
+	{
+	}
+
+	ThreadLocalMemoryResourcePool::~ThreadLocalMemoryResourcePool() = default;
+
+	ThreadLocalMemoryResourcePool::Arena &ThreadLocalMemoryResourcePool::GetLocalArena()
+	{
+		// Fast path: a thread-local single-entry cache keyed by the pool's unique generation id.
+		// Allocations cluster by pool (a batch of frame allocations, then a batch of scene
+		// allocations), so this hits nearly always and avoids the hash lookup below on the hot
+		// path. Keying by the never-reused generation (not `this`) avoids a false hit when a new
+		// pool reuses a destroyed pool's address. cachedGeneration 0 never matches a real id.
+		thread_local std::uint64_t cachedGeneration = 0;
+		thread_local Arena *cachedArena = nullptr;
+		if (cachedGeneration == m_generation)
+		{
+			return *cachedArena;
+		}
+
+		// Slow path: per-thread map keyed by generation, so the frame and scene pools can share
+		// the same thread without colliding. The cached Arena* points into m_arenas, which owns it.
+		thread_local std::unordered_map<std::uint64_t, Arena *> tlsArenas;
+
+		Arena *arenaPtr = nullptr;
+		if (const auto it = tlsArenas.find(m_generation); it != tlsArenas.end())
+		{
+			arenaPtr = it->second;
+		}
+		else
+		{
+			// First allocation on this thread for this pool: create the arena and register it so
+			// Reset() (and teardown) can reach it. Arenas spill through m_countingUpstream so the
+			// pool can measure exactly how much overflowed the initial buffers.
+			auto arena = std::make_unique<Arena>(m_initialArenaSize, &m_countingUpstream);
+			arenaPtr = arena.get();
+			{
+				std::lock_guard lock(m_mutex);
+				m_arenas.push_back(std::move(arena));
+			}
+			tlsArenas.emplace(m_generation, arenaPtr);
+		}
+
+		cachedGeneration = m_generation;
+		cachedArena = arenaPtr;
+		return *arenaPtr;
+	}
+
+	void *ThreadLocalMemoryResourcePool::do_allocate(std::size_t bytes, std::size_t alignment)
+	{
+		Arena &arena = GetLocalArena();
+		arena.bytesRequested += bytes;
+		++arena.allocationCount;
+		return arena.resource->allocate(bytes, alignment);
+	}
+
+	void ThreadLocalMemoryResourcePool::do_deallocate(void * /*ptr*/, std::size_t /*bytes*/,
+													  std::size_t /*alignment*/) noexcept
+	{
+		// Monotonic: individual deallocations are no-ops. Memory is reclaimed en masse by Reset().
+	}
+
+	bool ThreadLocalMemoryResourcePool::do_is_equal(const std::pmr::memory_resource &other) const noexcept
+	{
+		return this == &other;
+	}
+
+	void ThreadLocalMemoryResourcePool::Reset()
+	{
+		std::lock_guard lock(m_mutex);
+
+		// Snapshot spillover (upstream traffic since the last Reset), then zero it for the next
+		// cycle. Safe to reset here: no thread is allocating at the barrier.
+		m_lastSpilledBytes = m_countingUpstream.spilledBytes.exchange(0, std::memory_order_relaxed);
+		m_lastSpilledAllocations = m_countingUpstream.spilledAllocations.exchange(0, std::memory_order_relaxed);
+
+		std::size_t bytesRequested = 0;
+		std::size_t allocationCount = 0;
+		for (const std::unique_ptr<Arena> &arena : m_arenas)
+		{
+			bytesRequested += arena->bytesRequested;
+			allocationCount += arena->allocationCount;
+			arena->bytesRequested = 0;
+			arena->allocationCount = 0;
+			arena->Rewind();
+		}
+
+		m_lastBytesRequested = bytesRequested;
+		m_lastAllocationCount = allocationCount;
+		m_highWaterBytes = std::max(m_highWaterBytes, bytesRequested);
+		m_arenaCount = m_arenas.size();
+	}
+
+	ThreadLocalMemoryResourcePool::Stats ThreadLocalMemoryResourcePool::GetStats() const noexcept
+	{
+		return Stats{
+			.bytesRequestedLastCycle = m_lastBytesRequested,
+			.allocationCountLastCycle = m_lastAllocationCount,
+			.spilledBytesLastCycle = m_lastSpilledBytes,
+			.spilledAllocationsLastCycle = m_lastSpilledAllocations,
+			.highWaterBytes = m_highWaterBytes,
+			.arenaCount = m_arenaCount,
+			.initialArenaSize = m_initialArenaSize,
+		};
+	}
+} // namespace Hush::Memory

--- a/src/engine_core/memory/src/Hush/Memory/ThreadLocalMemoryResourcePool.hpp
+++ b/src/engine_core/memory/src/Hush/Memory/ThreadLocalMemoryResourcePool.hpp
@@ -1,0 +1,207 @@
+/*! \file ThreadLocalMemoryResourcePool.hpp
+	\author Alan Ramirez Herrera
+	\date 2026-07-01
+	\brief A thread-safe, resettable bump allocator (std::pmr::memory_resource) for
+		   frame- and scene-scoped temporary allocations.
+*/
+
+#pragma once
+
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <memory_resource>
+#include <mutex>
+#include <optional>
+#include <vector>
+
+namespace Hush::Memory
+{
+	/// A thread-safe, resettable bump allocator built on top of `std::pmr`.
+	///
+	/// Every thread that allocates from this resource is handed its own
+	/// `std::pmr::monotonic_buffer_resource`, backed by an owned initial buffer. Allocation
+	/// is a pointer bump (there is no per-allocation deallocation); `Reset()` rewinds every
+	/// thread's arena at once, reusing the initial buffers so no memory is returned to the
+	/// upstream resource on the common path.
+	///
+	/// It is intended to back the engine's frame- and scene-scoped memory resources
+	/// (see `HushEngine::GetFrameScopeMemoryResource` / `GetSceneScopeAllocator`).
+	///
+	/// ## Threading contract
+	/// - `do_allocate` / `do_deallocate` are safe to call concurrently from many threads:
+	///   each call only touches the calling thread's own arena. A short mutex is taken only
+	///   the first time a given thread allocates from a given pool (to register its arena).
+	/// - `Reset()` must ONLY be called at a barrier where no other thread is allocating from
+	///   this resource (e.g. the end-of-frame synchronization point, or scene teardown). It
+	///   walks and rewinds every thread's arena, which would race with a concurrent
+	///   allocation.
+	///
+	/// ## Lifetime
+	/// Instances are expected to outlive every thread that allocates from them (they are
+	/// members of the engine and live for the whole engine lifetime). The per-thread arena
+	/// lookup caches a raw pointer keyed by the pool instance; destroying a pool while a
+	/// thread still holds a cached entry for it (and then reusing the same address for a new
+	/// pool) would be undefined. This does not happen for the engine-owned pools.
+	class ThreadLocalMemoryResourcePool final : public std::pmr::memory_resource
+	{
+	public:
+		/// Default size, in bytes, of each thread's initial (reused) buffer.
+		static constexpr std::size_t DEFAULT_ARENA_SIZE = std::size_t{256} * 1024;
+
+		/// A snapshot of the pool's usage, produced at each `Reset()`. All figures are for the
+		/// cycle that just ended (a frame for the frame pool, a scene's lifetime for the scene
+		/// pool), except `highWaterBytes`, which is the running maximum across all cycles.
+		///
+		/// `bytesRequestedLastCycle` counts the sizes passed to `allocate` (excludes alignment
+		/// padding). `spilledBytesLastCycle` counts what the arenas actually pulled from the
+		/// upstream resource when their initial buffers were exhausted — i.e. `spilledBytes > 0`
+		/// means the arena size is too small for that cycle's peak.
+		struct Stats
+		{
+			std::size_t bytesRequestedLastCycle;
+			std::size_t allocationCountLastCycle;
+			std::size_t spilledBytesLastCycle;
+			std::size_t spilledAllocationsLastCycle;
+			std::size_t highWaterBytes;
+			std::size_t arenaCount;
+			std::size_t initialArenaSize;
+		};
+
+		/// @param initialArenaSize Size of each thread's reusable initial buffer, in bytes.
+		/// @param upstream Resource used for spillover past the initial buffer. Defaults to
+		///        `new_delete_resource`, which routes through mimalloc via the global
+		///        `operator new` overrides.
+		explicit ThreadLocalMemoryResourcePool(
+			std::size_t initialArenaSize = DEFAULT_ARENA_SIZE,
+			std::pmr::memory_resource *upstream = std::pmr::new_delete_resource()) noexcept;
+
+		ThreadLocalMemoryResourcePool(const ThreadLocalMemoryResourcePool &) = delete;
+		ThreadLocalMemoryResourcePool &operator=(const ThreadLocalMemoryResourcePool &) = delete;
+		ThreadLocalMemoryResourcePool(ThreadLocalMemoryResourcePool &&) = delete;
+		ThreadLocalMemoryResourcePool &operator=(ThreadLocalMemoryResourcePool &&) = delete;
+
+		~ThreadLocalMemoryResourcePool() override;
+
+		/// Rewinds every thread's arena, reusing the initial buffers. Spillover blocks are
+		/// released back to the upstream resource.
+		///
+		/// @warning See the threading contract in the class documentation: this must only be
+		///          called at a barrier where no thread is allocating from this pool.
+		void Reset();
+
+		/// Returns the usage snapshot taken at the last `Reset()`. Intended to be read on the
+		/// same thread that drives `Reset()` (e.g. the main loop) — it reads plain members that
+		/// are written only inside `Reset()` at the barrier.
+		[[nodiscard]]
+		Stats GetStats() const noexcept;
+
+	protected:
+		void *do_allocate(std::size_t bytes, std::size_t alignment) override;
+		void do_deallocate(void *ptr, std::size_t bytes, std::size_t alignment) noexcept override;
+		[[nodiscard]]
+		bool do_is_equal(const std::pmr::memory_resource &other) const noexcept override;
+
+	private:
+		/// A `memory_resource` that forwards to a wrapped upstream while counting what passes
+		/// through it. Every per-thread arena uses this as its monotonic resource's upstream, so
+		/// it counts exactly the memory pulled from upstream when an initial buffer is exhausted
+		/// (spillover). The atomics are touched only on that cold path.
+		struct CountingUpstream final : std::pmr::memory_resource
+		{
+			explicit CountingUpstream(std::pmr::memory_resource *wrapped) noexcept
+				: m_wrapped(wrapped)
+			{
+			}
+
+			std::atomic<std::size_t> spilledBytes{0};
+			std::atomic<std::size_t> spilledAllocations{0};
+
+		protected:
+			void *do_allocate(std::size_t bytes, std::size_t alignment) override
+			{
+				spilledBytes.fetch_add(bytes, std::memory_order_relaxed);
+				spilledAllocations.fetch_add(1, std::memory_order_relaxed);
+				return m_wrapped->allocate(bytes, alignment);
+			}
+
+			void do_deallocate(void *ptr, std::size_t bytes, std::size_t alignment) noexcept override
+			{
+				// Frees of spillover chunks (on Rewind/teardown) are not subtracted: the spill
+				// counters measure per-cycle upstream traffic and are zeroed in Reset().
+				m_wrapped->deallocate(ptr, bytes, alignment);
+			}
+
+			[[nodiscard]]
+			bool do_is_equal(const std::pmr::memory_resource &other) const noexcept override
+			{
+				return this == &other;
+			}
+
+		private:
+			std::pmr::memory_resource *m_wrapped;
+		};
+
+		/// A single thread's arena: an owned buffer plus the monotonic resource over it.
+		/// Stored behind a `unique_ptr` so it never moves after construction — the monotonic
+		/// resource holds a pointer into `buffer`.
+		struct Arena
+		{
+			Arena(std::size_t bufferSize, std::pmr::memory_resource *upstreamResource)
+				: buffer(std::make_unique<std::byte[]>(bufferSize)),
+				  size(bufferSize),
+				  upstream(upstreamResource),
+				  resource(std::in_place, buffer.get(), bufferSize, upstreamResource)
+			{
+			}
+
+			/// Rewinds this arena for reuse. We destroy and reconstruct the monotonic resource
+			/// over the same buffer rather than calling release(): that guarantees the bump
+			/// pointer resets to the start of the initial buffer (release() is not portably
+			/// guaranteed to rewind an externally-provided buffer). The destructor frees any
+			/// upstream spillover blocks; the owned `buffer` persists across rewinds.
+			void Rewind()
+			{
+				resource.emplace(buffer.get(), size, upstream);
+			}
+
+			std::unique_ptr<std::byte[]> buffer;
+			std::size_t size;
+			std::pmr::memory_resource *upstream;
+			std::optional<std::pmr::monotonic_buffer_resource> resource;
+
+			// Usage since the last Reset(). Written only by the owning thread in do_allocate;
+			// read+zeroed by Reset() at the barrier. Plain (no atomics) — single writer.
+			std::size_t bytesRequested = 0;
+			std::size_t allocationCount = 0;
+		};
+
+		/// Returns (creating + registering on first use) the calling thread's arena.
+		Arena &GetLocalArena();
+
+		// Unique per-instance id used to key the thread-local arena cache/map. Using a
+		// never-reused id (rather than `this`) avoids a false cache hit when a destroyed pool's
+		// address is reused by a new pool (e.g. stack-allocated pools in tests).
+		std::uint64_t m_generation;
+
+		std::size_t m_initialArenaSize;
+		std::pmr::memory_resource *m_upstream;
+		// Wraps m_upstream to count spillover; every arena uses &m_countingUpstream as upstream.
+		// Declared after m_upstream so it is constructed from an initialized pointer.
+		CountingUpstream m_countingUpstream;
+
+		// Owns every per-thread arena. Guarded by m_mutex for registration/reset/teardown.
+		std::mutex m_mutex;
+		std::vector<std::unique_ptr<Arena>> m_arenas;
+
+		// Usage snapshot, written only inside Reset() (main thread, at the barrier).
+		std::size_t m_lastBytesRequested = 0;
+		std::size_t m_lastAllocationCount = 0;
+		std::size_t m_lastSpilledBytes = 0;
+		std::size_t m_lastSpilledAllocations = 0;
+		std::size_t m_highWaterBytes = 0;
+		std::size_t m_arenaCount = 0;
+	};
+} // namespace Hush::Memory

--- a/src/engine_core/memory/tests/AllocatorBenchmark.test.cpp
+++ b/src/engine_core/memory/tests/AllocatorBenchmark.test.cpp
@@ -1,0 +1,117 @@
+/*! \file AllocatorBenchmark.test.cpp
+	\author Alan Ramirez Herrera
+	\date 2026-07-01
+	\brief Microbenchmarks for the memory allocators. Hidden by default ([.]); run with:
+		   HushMemoryTest "[benchmark]"
+
+	The coroutine-pool numbers answer the open question in CoroutineFrameResource.hpp: is the
+	pooled resource actually faster than plain operator new (which mimalloc already backs)?
+*/
+
+#include "Hush/Memory/CoroutineFrameResource.hpp"
+#include "Hush/Memory/ThreadLocalMemoryResourcePool.hpp"
+
+#include <catch2/benchmark/catch_benchmark.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstddef>
+#include <new>
+#include <vector>
+
+#if defined(HUSH_USE_MIMALLOC)
+#include <mimalloc.h>
+#endif
+
+using Hush::Memory::CoroutineFrameResource;
+using Hush::Memory::ThreadLocalMemoryResourcePool;
+
+TEST_CASE("Benchmark: coroutine frame alloc+free vs operator new", "[.][benchmark]")
+{
+	constexpr std::size_t ALIGN = __STDCPP_DEFAULT_NEW_ALIGNMENT__;
+	std::pmr::memory_resource *pool = CoroutineFrameResource();
+
+	// 96 B and 160 B bracket the measured hot coroutine frame sizes in an optimized build
+	// (payloads 96/128/160 are >99.9% of frames). Debug frames are larger (~192-272 B), but the
+	// pool only runs in optimized/Emscripten builds, so these are the representative sizes.
+	BENCHMARK("coroutine pool: alloc+free 96B")
+	{
+		void *p = pool->allocate(96, ALIGN);
+		pool->deallocate(p, 96, ALIGN);
+		return p;
+	};
+
+	BENCHMARK("operator new: alloc+free 96B")
+	{
+		void *p = ::operator new(96);
+		::operator delete(p, 96);
+		return p;
+	};
+
+	BENCHMARK("coroutine pool: alloc+free 160B")
+	{
+		void *p = pool->allocate(160, ALIGN);
+		pool->deallocate(p, 160, ALIGN);
+		return p;
+	};
+
+	BENCHMARK("operator new: alloc+free 160B")
+	{
+		void *p = ::operator new(160);
+		::operator delete(p, 160);
+		return p;
+	};
+
+#if defined(HUSH_USE_MIMALLOC)
+	// The real baseline: un-pooled coroutine frames hit mimalloc via the global operator new
+	// override. (::operator new above is CRT malloc here — the test exe is not minject'd.)
+	BENCHMARK("mimalloc: alloc+free 96B")
+	{
+		void *p = mi_malloc(96);
+		mi_free(p);
+		return p;
+	};
+
+	BENCHMARK("mimalloc: alloc+free 160B")
+	{
+		void *p = mi_malloc(160);
+		mi_free(p);
+		return p;
+	};
+#endif
+}
+
+TEST_CASE("Benchmark: frame arena batch-bump vs operator new", "[.][benchmark]")
+{
+	constexpr std::size_t ALIGN = alignof(std::max_align_t);
+	constexpr int BATCH = 256;
+
+	// Constructed once (owns a 1 MB buffer); each iteration bumps BATCH times then rewinds.
+	ThreadLocalMemoryResourcePool pool(std::size_t{1} * 1024 * 1024);
+
+	BENCHMARK("frame arena: 256x64B bump + reset")
+	{
+		void *last = nullptr;
+		for (int i = 0; i < BATCH; ++i)
+		{
+			last = pool.allocate(64, ALIGN);
+		}
+		pool.Reset();
+		return last;
+	};
+
+	BENCHMARK("operator new: 256x64B new + delete")
+	{
+		std::vector<void *> ptrs;
+		ptrs.reserve(BATCH);
+		for (int i = 0; i < BATCH; ++i)
+		{
+			ptrs.push_back(::operator new(64));
+		}
+		void *last = ptrs.empty() ? nullptr : ptrs.back();
+		for (void *p : ptrs)
+		{
+			::operator delete(p, 64);
+		}
+		return last;
+	};
+}

--- a/src/engine_core/memory/tests/CoroutineFrameResource.test.cpp
+++ b/src/engine_core/memory/tests/CoroutineFrameResource.test.cpp
@@ -1,0 +1,78 @@
+/*! \file CoroutineFrameResource.test.cpp
+	\author Alan Ramirez Herrera
+	\date 2026-07-01
+	\brief Tests for the coroutine frame memory resource.
+*/
+
+#include "Hush/Memory/CoroutineFrameResource.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstring>
+#include <new>
+#include <thread>
+
+TEST_CASE("Coroutine frame resource is a stable singleton", "[memory]")
+{
+	std::pmr::memory_resource *a = Hush::Memory::CoroutineFrameResource();
+	std::pmr::memory_resource *b = Hush::Memory::CoroutineFrameResource();
+	REQUIRE(a != nullptr);
+	REQUIRE(a == b);
+}
+
+TEST_CASE("Coroutine frame resource allocate/deallocate on the same thread", "[memory]")
+{
+	std::pmr::memory_resource *mr = Hush::Memory::CoroutineFrameResource();
+
+	void *p = mr->allocate(96, __STDCPP_DEFAULT_NEW_ALIGNMENT__);
+	REQUIRE(p != nullptr);
+	std::memset(p, 0x5A, 96);
+	mr->deallocate(p, 96, __STDCPP_DEFAULT_NEW_ALIGNMENT__);
+}
+
+TEST_CASE("Coroutine frame resource allows cross-thread deallocation", "[memory]")
+{
+	// Work-stealing means a coroutine frame allocated on one thread may be freed on another.
+	// The resource must tolerate that; allocate on this thread, free on a worker thread.
+	std::pmr::memory_resource *mr = Hush::Memory::CoroutineFrameResource();
+
+	constexpr std::size_t SIZE = 128;
+	void *p = mr->allocate(SIZE, __STDCPP_DEFAULT_NEW_ALIGNMENT__);
+	REQUIRE(p != nullptr);
+	std::memset(p, 0x33, SIZE);
+
+	std::thread worker([mr, p] { mr->deallocate(p, SIZE, __STDCPP_DEFAULT_NEW_ALIGNMENT__); });
+	worker.join();
+
+	SUCCEED("cross-thread deallocation did not corrupt the resource");
+}
+
+TEST_CASE("Coroutine frame resource under concurrent churn", "[memory]")
+{
+	std::pmr::memory_resource *mr = Hush::Memory::CoroutineFrameResource();
+
+	constexpr int NUM_THREADS = 8;
+	constexpr int ITERATIONS = 512;
+
+	std::vector<std::thread> threads;
+	threads.reserve(NUM_THREADS);
+	for (int t = 0; t < NUM_THREADS; ++t)
+	{
+		threads.emplace_back([mr] {
+			for (int i = 0; i < ITERATIONS; ++i)
+			{
+				const std::size_t size = 16 + static_cast<std::size_t>(i % 240);
+				void *p = mr->allocate(size, __STDCPP_DEFAULT_NEW_ALIGNMENT__);
+				REQUIRE(p != nullptr);
+				std::memset(p, 0x1, size);
+				mr->deallocate(p, size, __STDCPP_DEFAULT_NEW_ALIGNMENT__);
+			}
+		});
+	}
+	for (std::thread &thread : threads)
+	{
+		thread.join();
+	}
+
+	SUCCEED("concurrent allocate/deallocate churn completed");
+}

--- a/src/engine_core/memory/tests/MakeNullTerminated.test.cpp
+++ b/src/engine_core/memory/tests/MakeNullTerminated.test.cpp
@@ -1,0 +1,58 @@
+/*! \file MakeNullTerminated.test.cpp
+	\author Alan Ramirez Herrera
+	\date 2026-07-01
+	\brief Tests for the MakeNullTerminated string helper (utils), exercised through a
+		   ThreadLocalMemoryResourcePool arena.
+*/
+
+#include "Hush/Memory/ThreadLocalMemoryResourcePool.hpp"
+#include "StringAllocation.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstring>
+#include <string_view>
+
+TEST_CASE("MakeNullTerminated null-terminates an arbitrary view", "[memory][string]")
+{
+	Hush::Memory::ThreadLocalMemoryResourcePool pool;
+
+	// A view that is deliberately NOT null-terminated: a slice of a larger buffer.
+	constexpr std::string_view backing = "hello world";
+	const std::string_view slice = backing.substr(0, 5); // "hello", followed by ' ' not '\0'
+
+	const Hush::NullTerminatedStringView z = Hush::MakeNullTerminated(slice, &pool);
+
+	REQUIRE(z.size() == 5);
+	REQUIRE(std::string_view(z) == "hello");
+	REQUIRE(z.c_str()[z.size()] == '\0');
+	// Usable as a C string.
+	REQUIRE(std::strlen(z.c_str()) == 5);
+	// The copy is independent of the backing storage.
+	REQUIRE(z.c_str() != slice.data());
+}
+
+TEST_CASE("MakeNullTerminated handles the empty view", "[memory][string]")
+{
+	Hush::Memory::ThreadLocalMemoryResourcePool pool;
+
+	const Hush::NullTerminatedStringView z = Hush::MakeNullTerminated(std::string_view{}, &pool);
+
+	REQUIRE(z.size() == 0);
+	REQUIRE(z.empty());
+	REQUIRE(z.c_str() != nullptr);
+	REQUIRE(z.c_str()[0] == '\0');
+}
+
+TEST_CASE("MakeNullTerminated preserves embedded content and length", "[memory][string]")
+{
+	Hush::Memory::ThreadLocalMemoryResourcePool pool;
+
+	const std::string_view source = "entity/name/with/slashes";
+	const Hush::NullTerminatedStringView z = Hush::MakeNullTerminated(source, &pool);
+
+	REQUIRE(z.size() == source.size());
+	REQUIRE(std::string_view(z) == source);
+	REQUIRE(std::memcmp(z.c_str(), source.data(), source.size()) == 0);
+	REQUIRE(z.c_str()[source.size()] == '\0');
+}

--- a/src/engine_core/memory/tests/ThreadLocalMemoryResourcePool.test.cpp
+++ b/src/engine_core/memory/tests/ThreadLocalMemoryResourcePool.test.cpp
@@ -1,0 +1,185 @@
+/*! \file ThreadLocalMemoryResourcePool.test.cpp
+	\author Alan Ramirez Herrera
+	\date 2026-07-01
+	\brief Tests for ThreadLocalMemoryResourcePool.
+*/
+
+#include "Hush/Memory/ThreadLocalMemoryResourcePool.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <thread>
+#include <vector>
+
+using Hush::Memory::ThreadLocalMemoryResourcePool;
+
+namespace
+{
+	bool IsAligned(const void *ptr, std::size_t alignment) noexcept
+	{
+		return (reinterpret_cast<std::uintptr_t>(ptr) % alignment) == 0;
+	}
+
+	// Consumes an allocation whose pointer the test doesn't need (it only inspects stats),
+	// silencing MSVC C4858 (discarding a raw-pointer allocation result).
+	void Consume(void * /*ptr*/) noexcept
+	{
+	}
+} // namespace
+
+TEST_CASE("Frame pool basic allocation is usable and aligned", "[memory]")
+{
+	ThreadLocalMemoryResourcePool pool;
+
+	void *a = pool.allocate(64, alignof(std::max_align_t));
+	void *b = pool.allocate(128, alignof(std::max_align_t));
+
+	REQUIRE(a != nullptr);
+	REQUIRE(b != nullptr);
+	REQUIRE(a != b);
+	REQUIRE(IsAligned(a, alignof(std::max_align_t)));
+	REQUIRE(IsAligned(b, alignof(std::max_align_t)));
+
+	// The memory must be writable.
+	std::memset(a, 0xAB, 64);
+	std::memset(b, 0xCD, 128);
+}
+
+TEST_CASE("Frame pool honours over-alignment", "[memory]")
+{
+	ThreadLocalMemoryResourcePool pool;
+
+	for (int i = 0; i < 8; ++i)
+	{
+		void *p = pool.allocate(1, 64);
+		REQUIRE(p != nullptr);
+		REQUIRE(IsAligned(p, 64));
+	}
+}
+
+TEST_CASE("Reset rewinds the initial buffer for reuse", "[memory]")
+{
+	// Small initial buffer so we stay within it.
+	ThreadLocalMemoryResourcePool pool(/*initialArenaSize=*/1024);
+
+	void *first = pool.allocate(64, alignof(std::max_align_t));
+	void *second = pool.allocate(64, alignof(std::max_align_t));
+	REQUIRE(second != first);
+
+	pool.Reset();
+
+	// After a reset the arena starts over from the beginning of the same buffer, so the first
+	// allocation of the same size/alignment lands at the same address.
+	void *afterReset = pool.allocate(64, alignof(std::max_align_t));
+	REQUIRE(afterReset == first);
+}
+
+TEST_CASE("Allocations larger than the initial buffer spill to upstream", "[memory]")
+{
+	ThreadLocalMemoryResourcePool pool(/*initialArenaSize=*/256);
+
+	// Much larger than the initial buffer: must still succeed via the upstream resource.
+	void *big = pool.allocate(4096, alignof(std::max_align_t));
+	REQUIRE(big != nullptr);
+	std::memset(big, 0x11, 4096);
+
+	// Reset must reclaim the spillover without crashing, and keep working afterwards.
+	pool.Reset();
+	void *again = pool.allocate(4096, alignof(std::max_align_t));
+	REQUIRE(again != nullptr);
+}
+
+TEST_CASE("Concurrent allocation from many threads then reset at a barrier", "[memory]")
+{
+	ThreadLocalMemoryResourcePool pool(/*initialArenaSize=*/4096);
+
+	constexpr int NUM_THREADS = 8;
+	constexpr int ALLOCS_PER_THREAD = 256;
+
+	std::vector<std::thread> threads;
+	threads.reserve(NUM_THREADS);
+	for (int t = 0; t < NUM_THREADS; ++t)
+	{
+		threads.emplace_back([&pool] {
+			for (int i = 0; i < ALLOCS_PER_THREAD; ++i)
+			{
+				void *p = pool.allocate(48, alignof(std::max_align_t));
+				REQUIRE(p != nullptr);
+				// Touch the memory to catch overlapping allocations under a sanitizer.
+				std::memset(p, 0x7F, 48);
+			}
+		});
+	}
+	for (std::thread &thread : threads)
+	{
+		thread.join();
+	}
+
+	// All workers are joined (quiescent): resetting is safe here.
+	pool.Reset();
+
+	void *p = pool.allocate(48, alignof(std::max_align_t));
+	REQUIRE(p != nullptr);
+}
+
+TEST_CASE("GetStats reports per-cycle usage without spilling within the buffer", "[memory]")
+{
+	constexpr std::size_t ARENA = 4096;
+	ThreadLocalMemoryResourcePool pool(ARENA);
+
+	// Three allocations well within the initial buffer.
+	Consume(pool.allocate(64, alignof(std::max_align_t)));
+	Consume(pool.allocate(128, alignof(std::max_align_t)));
+	Consume(pool.allocate(32, alignof(std::max_align_t)));
+
+	pool.Reset();
+
+	const auto stats = pool.GetStats();
+	REQUIRE(stats.bytesRequestedLastCycle == 64 + 128 + 32);
+	REQUIRE(stats.allocationCountLastCycle == 3);
+	REQUIRE(stats.spilledBytesLastCycle == 0);
+	REQUIRE(stats.spilledAllocationsLastCycle == 0);
+	REQUIRE(stats.highWaterBytes == 64 + 128 + 32);
+	REQUIRE(stats.arenaCount == 1);
+	REQUIRE(stats.initialArenaSize == ARENA);
+}
+
+TEST_CASE("GetStats reports spillover when allocations exceed the buffer", "[memory]")
+{
+	constexpr std::size_t ARENA = 256;
+	ThreadLocalMemoryResourcePool pool(ARENA);
+
+	// Comfortably larger than the initial buffer: the arena must pull from upstream.
+	Consume(pool.allocate(4096, alignof(std::max_align_t)));
+	pool.Reset();
+
+	const auto stats = pool.GetStats();
+	REQUIRE(stats.bytesRequestedLastCycle == 4096);
+	REQUIRE(stats.allocationCountLastCycle == 1);
+	REQUIRE(stats.spilledBytesLastCycle > 0);
+	REQUIRE(stats.spilledAllocationsLastCycle > 0);
+}
+
+TEST_CASE("GetStats high-water mark is the running maximum across cycles", "[memory]")
+{
+	ThreadLocalMemoryResourcePool pool(4096);
+
+	Consume(pool.allocate(512, alignof(std::max_align_t)));
+	pool.Reset();
+	REQUIRE(pool.GetStats().highWaterBytes == 512);
+
+	// A bigger cycle raises the high-water mark.
+	Consume(pool.allocate(1024, alignof(std::max_align_t)));
+	pool.Reset();
+	REQUIRE(pool.GetStats().highWaterBytes == 1024);
+
+	// A smaller cycle does not lower it, and the per-cycle figure reflects only this cycle.
+	Consume(pool.allocate(128, alignof(std::max_align_t)));
+	pool.Reset();
+	const auto stats = pool.GetStats();
+	REQUIRE(stats.bytesRequestedLastCycle == 128);
+	REQUIRE(stats.highWaterBytes == 1024);
+}

--- a/src/engine_core/rendering/src/RHI/ShaderCompiler.cpp
+++ b/src/engine_core/rendering/src/RHI/ShaderCompiler.cpp
@@ -399,7 +399,8 @@ namespace Hush::Graphics
 		return m_options.target;
 	}
 
-	ShaderCompilationResult ShaderCompiler::CompileFromSource(std::string_view source, std::string_view sourceName,
+	ShaderCompilationResult ShaderCompiler::CompileFromSource(NullTerminatedStringView source,
+															  NullTerminatedStringView sourceName,
 															  const std::vector<ShaderEntryPointRequest> &entryPoints)
 	{
 		if (!m_initialized)
@@ -410,17 +411,15 @@ namespace Hush::Graphics
 			return failResult;
 		}
 
-		std::string nameStr(sourceName);
-
 		// Check cache
-		std::string cacheKey = BuildCacheKey(nameStr.c_str(), entryPoints);
+		std::string cacheKey = BuildCacheKey(sourceName, entryPoints);
 		auto cacheIt = m_cache.find(cacheKey);
 		if (cacheIt != m_cache.end())
 		{
 			return cacheIt->second;
 		}
 
-		auto result = CompileInternal(nameStr.c_str(), source.data(), source.size(), entryPoints);
+		auto result = CompileInternal(sourceName, source, entryPoints);
 
 		// Cache the result
 		m_cache[cacheKey] = result;
@@ -492,8 +491,8 @@ namespace Hush::Graphics
 		}
 	}
 
-	ShaderCompilationResult ShaderCompiler::CompileInternal(const char *moduleNameOrPath, const char *source,
-															size_t sourceLength,
+	ShaderCompilationResult ShaderCompiler::CompileInternal(NullTerminatedStringView moduleNameOrPath,
+															NullTerminatedStringView source,
 															const std::vector<ShaderEntryPointRequest> &entryPoints)
 	{
 		ShaderCompilationResult result;
@@ -563,16 +562,16 @@ namespace Hush::Graphics
 		Slang::ComPtr<ISlangBlob> diagnosticsBlob;
 		slang::IModule *module = nullptr;
 
-		if (source != nullptr && sourceLength > 0)
+		if (!source.empty())
 		{
 			// Load from source string
-			module = session->loadModuleFromSourceString(moduleNameOrPath,
-														 moduleNameOrPath, // virtual path for diagnostics
-														 source, diagnosticsBlob.writeRef());
+			module = session->loadModuleFromSourceString(moduleNameOrPath.c_str(),
+														 moduleNameOrPath.c_str(), // virtual path for diagnostics
+														 source.c_str(), diagnosticsBlob.writeRef());
 		}
 		else
 		{
-			module = session->loadModule(moduleNameOrPath, diagnosticsBlob.writeRef());
+			module = session->loadModule(moduleNameOrPath.c_str(), diagnosticsBlob.writeRef());
 		}
 
 		AppendDiagnostics(diagnosticsBlob.get(), result.diagnostics);
@@ -582,7 +581,7 @@ namespace Hush::Graphics
 			if (result.diagnostics.empty())
 			{
 				result.diagnostics = "Failed to load Slang module: ";
-				result.diagnostics += moduleNameOrPath;
+				result.diagnostics += moduleNameOrPath.c_str();
 			}
 			return result;
 		}
@@ -740,11 +739,11 @@ namespace Hush::Graphics
 		ReflectVertexInputs(layout, outResult.vertexInputs);
 	}
 
-	std::string ShaderCompiler::BuildCacheKey(const char *moduleNameOrPath,
+	std::string ShaderCompiler::BuildCacheKey(NullTerminatedStringView moduleNameOrPath,
 											  const std::vector<ShaderEntryPointRequest> &entryPoints) const
 	{
 		std::string key;
-		key += moduleNameOrPath;
+		key += moduleNameOrPath.c_str();
 		key += "|target=";
 		key += std::to_string(static_cast<uint32_t>(m_options.target));
 		key += "|opt=";

--- a/src/engine_core/rendering/src/RHI/ShaderCompiler.hpp
+++ b/src/engine_core/rendering/src/RHI/ShaderCompiler.hpp
@@ -11,10 +11,10 @@
 #include "IShaderModule.hpp"
 #include "PipelineDescriptor.hpp"
 
+#include <NullTerminatedStringView.hpp>
 #include <algorithm>
 #include <cstdint>
 #include <string>
-#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -243,7 +243,7 @@ namespace Hush::Graphics
 		/// @param entryPoints List of entry points to compile.
 		/// @return Compilation result.
 		[[nodiscard]]
-		ShaderCompilationResult CompileFromSource(std::string_view source, std::string_view sourceName,
+		ShaderCompilationResult CompileFromSource(NullTerminatedStringView source, NullTerminatedStringView sourceName,
 												  const std::vector<ShaderEntryPointRequest> &entryPoints);
 
 		/// @brief Clear all cached compilation results.
@@ -270,9 +270,8 @@ namespace Hush::Graphics
 	private:
 		/// @brief Shared compilation logic used by both CompileFromFile and
 		///        CompileFromSource.
-		ShaderCompilationResult CompileInternal(const char *moduleNameOrPath,
-												const char *source, // nullptr when compiling from file
-												size_t sourceLength,
+		ShaderCompilationResult CompileInternal(NullTerminatedStringView moduleNameOrPath,
+												NullTerminatedStringView source, // empty when compiling from file
 												const std::vector<ShaderEntryPointRequest> &entryPoints);
 
 		/// @brief Extract reflection data from a linked Slang program.
@@ -286,7 +285,7 @@ namespace Hush::Graphics
 
 		/// @brief Build a cache key from the compilation inputs.
 		[[nodiscard]]
-		std::string BuildCacheKey(const char *moduleNameOrPath,
+		std::string BuildCacheKey(NullTerminatedStringView moduleNameOrPath,
 								  const std::vector<ShaderEntryPointRequest> &entryPoints) const;
 
 		/// @brief Map an EShaderStage to the Slang SlangStage enum value.

--- a/src/engine_core/scripting/src/ScriptingHost.cpp
+++ b/src/engine_core/scripting/src/ScriptingHost.cpp
@@ -28,13 +28,13 @@ constexpr std::string_view CALL_SYSTEM_ON_POSTRENDER_FN_NAME = "CallSystemOnPost
 	} while (0)
 
 // NOLINTBEGIN
-void Hush::ScriptingHost::Initialize(std::string_view dllPath)
+void Hush::ScriptingHost::Initialize(NullTerminatedStringView dllPath)
 {
 	// TODO: reconcile with virtual filesystem
-	void *libraryHandle = LibManager::LibraryOpen(dllPath.data());
+	void *libraryHandle = LibManager::LibraryOpen(dllPath.c_str());
 
 	// This could be user side??? eventually
-	HUSH_COND_FAIL_MSG(libraryHandle != nullptr, "Could not load dynamic library at {}", dllPath);
+	HUSH_COND_FAIL_MSG(libraryHandle != nullptr, "Could not load dynamic library at {}", std::string_view(dllPath));
 
 	BIND_DLL_SCRIPTING_FUNCTION(START_SCRIPTING_CONNECTION, this->m_startScriptingConnectionFn);
 	BIND_DLL_SCRIPTING_FUNCTION(DISPOSE_SCRIPTING_CONNECTION, this->m_disposeScriptingConnectionFn);

--- a/src/engine_core/scripting/src/ScriptingHost.hpp
+++ b/src/engine_core/scripting/src/ScriptingHost.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Assertions.hpp"
+#include "NullTerminatedStringView.hpp"
 #include "Result.hpp"
 #include <string_view>
 #include <vector>
@@ -44,7 +45,7 @@ namespace Hush
 			"Function pointer is not initialized! Forgot to call ScriptingHost::Initialize?";
 
 		// We need to load an arbitrary DLL and communicate with it through C calls
-		void Initialize(std::string_view dllPath);
+		void Initialize(NullTerminatedStringView dllPath);
 
 		std::vector<ScriptingSystemInfo> &GetAvailableSystems();
 

--- a/src/engine_core/src/HushEngine.cpp
+++ b/src/engine_core/src/HushEngine.cpp
@@ -6,6 +6,7 @@
 #include "Systems/RenderGraphSystem.hpp"
 #include "Systems/ResourceUploadSystem.hpp"
 #include "WindowRenderer.hpp"
+#include "Hush/Memory/ThreadLocalMemoryResourcePool.hpp"
 #include "filesystem/CFileSystem/CFileSystem.hpp"
 #include <WindowManager.hpp>
 #include <algorithm>
@@ -26,6 +27,10 @@ extern "C" void HushForceLinkAllocatorOverrides() noexcept;
 #endif
 #include <vector>
 
+// Per-thread initial buffer size, in KB, for the frame and scene arenas.
+static constexpr std::size_t HUSH_FRAME_ARENA_SIZE_KB = 256;
+static constexpr std::size_t HUSH_SCENE_ARENA_SIZE_KB = 256;
+
 struct Hush::HushEngine::HushEngineInternal
 {
 	Hush::VirtualFilesystem vfs;
@@ -34,6 +39,8 @@ struct Hush::HushEngine::HushEngineInternal
 	std::unique_ptr<Graphics::RenderGraphSystem> renderGraphSystem;
 	std::unique_ptr<Hush::Renderer::ResourceUploadSystem> resourceUploadSystem;
 	std::unique_ptr<WindowRenderer> windowRenderer = nullptr;
+	Hush::Memory::ThreadLocalMemoryResourcePool frameMemoryPool{HUSH_FRAME_ARENA_SIZE_KB * 1024};
+	Hush::Memory::ThreadLocalMemoryResourcePool sceneMemoryPool{HUSH_SCENE_ARENA_SIZE_KB * 1024};
 };
 
 #if defined(HUSH_PLATFORM_EMSCRIPTEN)
@@ -67,6 +74,11 @@ void Hush::HushEngine::Init(int argc, char **argv)
 #endif
 
 	this->m_app = LoadApplication(this);
+
+	// Wire the engine-owned frame/scene memory resources into the scene, so it can cheaply
+	// materialize null-terminated strings for Flecs and allocate scene-lifetime data from the
+	// scene arena.
+	this->m_app->GetScene()->SetMemoryResources(&this->m_internal->frameMemoryPool, &this->m_internal->sceneMemoryPool);
 
 	// Check for --wait-profiler flag
 	std::span<char *> args(argv, static_cast<size_t>(argc));
@@ -122,6 +134,17 @@ void Hush::HushEngine::Run()
 	this->m_app->OnPostRender();
 	this->m_app->DisposeFrame();
 
+	this->m_internal->frameMemoryPool.Reset();
+
+	// Publish this frame's frame-arena usage to Tracy (no-op when profiling is off). The plots
+	// show whether the configured arena size is right: "Spill" > 0 means the buffer was too small.
+	const Hush::Memory::ThreadLocalMemoryResourcePool::Stats frameStats = this->m_internal->frameMemoryPool.GetStats();
+	TracyPlot("Frame Arena Bytes", static_cast<double>(frameStats.bytesRequestedLastCycle));
+	TracyPlot("Frame Arena Spill", static_cast<double>(frameStats.spilledBytesLastCycle));
+
+	// The scene-scoped pool is intentionally NOT reset here: its allocations persist across
+	// frames and are reclaimed on scene teardown via ResetSceneScopeMemory().
+
 	std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
 	m_elapsed = end - start;
 #ifndef HUSH_PLATFORM_EMSCRIPTEN
@@ -168,4 +191,19 @@ void Hush::HushEngine::AddDefaultSystems()
 Hush::ResourceManager *Hush::HushEngine::GetResourceManager() noexcept
 {
 	return &this->m_internal->resourceManager;
+}
+
+std::pmr::memory_resource *Hush::HushEngine::GetFrameScopeMemoryResource() noexcept
+{
+	return &this->m_internal->frameMemoryPool;
+}
+
+std::pmr::memory_resource *Hush::HushEngine::GetSceneScopeAllocator() noexcept
+{
+	return &this->m_internal->sceneMemoryPool;
+}
+
+void Hush::HushEngine::ResetSceneScopeMemory() noexcept
+{
+	this->m_internal->sceneMemoryPool.Reset();
 }

--- a/src/engine_core/src/HushEngine.hpp
+++ b/src/engine_core/src/HushEngine.hpp
@@ -10,9 +10,11 @@
 #include "HushBindings.hpp"
 #include "executors/ThreadPool.hpp"
 
+#include <memory_resource>
 #include <span>
 #include <string_view>
 #include <SDL3/SDL_events.h>
+#include <memory>
 
 namespace Hush
 {
@@ -73,6 +75,33 @@ namespace Hush
 		VirtualFilesystem *GetVirtualFilesystem() noexcept;
 
 		ResourceManager *GetResourceManager() noexcept;
+
+		/// Returns a pointer to the memory resource used for frame-scoped allocations.
+		///
+		/// This memory resource is for temporary allocations that will live only for the duration of this frame.
+		/// It resets at the end of each frame, allowing for efficient reuse of memory without fragmentation.
+		///
+		/// @note This is thread-safe. Each thread that calls this function
+		///       will receive a pointer to a thread-local memory resource managed by the engine.
+		///       All the created memory resources will be destroyed when the engine is destroyed.
+		///
+		/// @return A pointer to the frame scope memory resource.
+		std::pmr::memory_resource *GetFrameScopeMemoryResource() noexcept;
+
+		/// Returns a pointer to the memory resource used for scene-scoped allocations.
+		///
+		/// This memory resource is for allocations that should persist for the duration of a scene.
+		/// It resets when a new scene is loaded, allowing for efficient reuse of memory without fragmentation across
+		/// scenes.
+		///
+		/// @return A pointer to the scene scope memory resource.
+		std::pmr::memory_resource *GetSceneScopeAllocator() noexcept;
+
+		/// Rewinds the scene-scoped memory resource, reclaiming everything allocated from it.
+		///
+		/// Called when a scene is torn down (see `Scene::~Scene`). Must only be called once the
+		/// scene that owns those allocations is gone, so no live object still references them.
+		void ResetSceneScopeMemory() noexcept;
 
 	private:
 		void AddDefaultSystems();

--- a/src/engine_core/threading/CMakeLists.txt
+++ b/src/engine_core/threading/CMakeLists.txt
@@ -12,7 +12,7 @@ hush_add_library(
 )
 add_library(Hush::Threading ALIAS HushThreading)
 
-target_link_libraries(HushThreading PUBLIC Hush::Log Hush::Utils)
+target_link_libraries(HushThreading PUBLIC Hush::Log Hush::Utils Hush::Memory)
 
 if (linux)
     target_link_libraries(HushThreading PUBLIC pthread)
@@ -28,3 +28,7 @@ add_test_target(
         SRCS tests/ThreadPool.test.cpp
         HEADER_DIRS tests
 )
+
+# CoroutineFrameResource() (referenced by the coroutine promise operator new/delete) now lives
+# in the memory module's .cpp, so the test executable must link it.
+target_link_libraries(HushThreadingTest PRIVATE Hush::Memory)

--- a/src/engine_core/threading/src/async/SelfDeleteTask.hpp
+++ b/src/engine_core/threading/src/async/SelfDeleteTask.hpp
@@ -19,6 +19,10 @@ namespace Hush::Threading
 		class SelfDeletePromise
 		{
 		public:
+			// Detached task: its frame is freed on whatever worker completes it (possibly a
+			// different thread), which the coroutine resource is built to handle.
+			HUSH_COROUTINE_FRAME_ALLOCATOR()
+
 			SelfDeletePromise() noexcept = default;
 
 			SelfDeletePromise(SelfDeletePromise &&) noexcept = default;

--- a/src/engine_core/threading/src/async/SyncWait.hpp
+++ b/src/engine_core/threading/src/async/SyncWait.hpp
@@ -8,6 +8,7 @@
 
 // NOLINTBEGIN(readability-identifier-naming, modernize-use-nodiscard)
 
+#include "Hush/Memory/CoroutineFrameResource.hpp"
 #include "TaskTraits.hpp"
 #include <atomic>
 #include <coroutine>
@@ -22,6 +23,8 @@ namespace Hush::Threading
 	{
 		struct SyncWaitPromiseBase
 		{
+			HUSH_COROUTINE_FRAME_ALLOCATOR()
+
 			SyncWaitPromiseBase() noexcept = default;
 
 			SyncWaitPromiseBase(const SyncWaitPromiseBase &) = default;

--- a/src/engine_core/threading/src/async/Task.hpp
+++ b/src/engine_core/threading/src/async/Task.hpp
@@ -8,6 +8,8 @@
 
 // NOLINTBEGIN(readability-identifier-naming, modernize-use-nodiscard)
 
+#include "Hush/Memory/CoroutineFrameResource.hpp"
+
 #include <Logger.hpp>
 #include <cassert>
 #include <coroutine>
@@ -22,6 +24,10 @@ namespace Hush::Threading
 	{
 		struct PromiseBase
 		{
+			// Route this coroutine's frame allocation through the pooled, cross-thread-safe
+			// coroutine resource instead of global operator new. Covers every Task<T>.
+			HUSH_COROUTINE_FRAME_ALLOCATOR()
+
 			std::coroutine_handle<> continuation;
 
 			struct FinalAwaiter

--- a/src/engine_core/threading/src/async/WhenAll.hpp
+++ b/src/engine_core/threading/src/async/WhenAll.hpp
@@ -8,6 +8,7 @@
 // NOLINTBEGIN(readability-identifier-naming,modernize-use-nodiscard)
 
 #include "Assertions.hpp"
+#include "Hush/Memory/CoroutineFrameResource.hpp"
 #include "TaskTraits.hpp"
 
 #include <atomic>
@@ -322,6 +323,8 @@ namespace Hush::Threading
 		class WhenAllTasksPromise
 		{
 		public:
+			HUSH_COROUTINE_FRAME_ALLOCATOR()
+
 			using coroutine_handle_type = std::coroutine_handle<WhenAllTasksPromise<T>>;
 
 			WhenAllTasksPromise() = default;
@@ -408,6 +411,8 @@ namespace Hush::Threading
 		class WhenAllTasksPromise<void>
 		{
 		public:
+			HUSH_COROUTINE_FRAME_ALLOCATOR()
+
 			using coroutine_handle_type = std::coroutine_handle<WhenAllTasksPromise<void>>;
 			WhenAllTasksPromise() = default;
 

--- a/src/engine_core/utils/src/NullTerminatedStringView.hpp
+++ b/src/engine_core/utils/src/NullTerminatedStringView.hpp
@@ -1,0 +1,122 @@
+/*! \file NullTerminatedStringView.hpp
+	\author Alan Ramirez Herrera
+	\date 2026-05-20
+	\brief A string view that guarantees null-termination, useful for C APIs and interop scenarios where null-terminated
+   strings are required.
+*/
+
+#pragma once
+
+#include "Assertions.hpp"
+#include <string_view>
+#include <cstring>
+#include <string>
+
+namespace Hush
+{
+	class NullTerminatedStringView
+	{
+	public:
+		using value_type = char;
+		using const_pointer = const char *;
+		using size_type = std::size_t;
+
+		constexpr NullTerminatedStringView() noexcept = default;
+
+		/// Construct from a string literal or any `const char[N]` array.
+		///
+		/// This matches any const char array, not only string literals — that's the limit
+		/// of what the type system can detect at compile time. Arrays passed here are
+		/// assumed to be properly null-terminated at index `N - 1`.
+		template <std::size_t N>
+		constexpr NullTerminatedStringView(const char (&literal)[N]) noexcept
+			: m_data(literal),
+			  m_size(N - 1)
+		{
+		}
+
+		/// Disable construction from a non-const char array. Without this, mutable buffers
+		/// like `char buf[64]; NullTerminatedStringView z = buf;` would slip through the
+		/// literal constructor above and capture whatever happens to be at `buf[strlen(buf)]`.
+		template <std::size_t N>
+		NullTerminatedStringView(char (&)[N]) = delete;
+
+		/// Construct from a `std::string`. `c_str()` is null-terminated since C++11.
+		NullTerminatedStringView(const std::string &s) noexcept
+			: m_data(s.c_str()),
+			  m_size(s.size())
+		{
+		}
+
+		/// Explicit, named factory for constructing from a `std::string_view`.
+		///
+		/// The caller asserts that the byte at `sv.data() + sv.size()` is `'\0'`.
+		/// This is checked in debug builds via `HUSH_ASSERT`.
+		[[nodiscard]]
+		static NullTerminatedStringView promise_null_terminated(std::string_view sv) noexcept
+		{
+			HUSH_ASSERT(sv.data() != nullptr, "promise_null_terminated requires a non-null string_view");
+			HUSH_ASSERT(sv.data()[sv.size()] == '\0',
+						"promise_null_terminated requires the byte at data()+size() to be a null terminator");
+			return NullTerminatedStringView{sv.data(), sv.size()};
+		}
+
+		/// Implicit conversion to the weaker view type.
+		constexpr operator std::string_view() const noexcept
+		{
+			return {m_data, m_size};
+		}
+
+		/// Pointer to the null-terminated character data. Never null after construction
+		/// from any of the supported sources (empty zstring_view points at `""`).
+		[[nodiscard]]
+		constexpr const char *c_str() const noexcept
+		{
+			return m_data;
+		}
+		[[nodiscard]]
+		constexpr const char *data() const noexcept
+		{
+			return m_data;
+		}
+		[[nodiscard]]
+		constexpr size_type size() const noexcept
+		{
+			return m_size;
+		}
+		[[nodiscard]]
+		constexpr bool empty() const noexcept
+		{
+			return m_size == 0;
+		}
+
+		[[nodiscard]]
+		constexpr const char &operator[](size_type i) const noexcept
+		{
+			return m_data[i];
+		}
+
+		// Equality and ordering delegate to string_view for consistency.
+		friend constexpr bool operator==(NullTerminatedStringView a, NullTerminatedStringView b) noexcept
+		{
+			return std::string_view(a) == std::string_view(b);
+		}
+
+		friend constexpr auto operator<=>(NullTerminatedStringView a, NullTerminatedStringView b) noexcept
+		{
+			return std::string_view(a) <=> std::string_view(b);
+		}
+
+	private:
+		constexpr NullTerminatedStringView(const char *data, size_type size) noexcept
+			: m_data(data),
+			  m_size(size)
+		{
+		}
+
+		// Empty zstring_view still satisfies the invariant: points at a static "".
+		static constexpr const char EMPTY_LITERAL[] = "";
+		const char *m_data = EMPTY_LITERAL;
+		size_type m_size = 0;
+	};
+} // namespace Hush

--- a/src/engine_core/utils/src/SharedLibrary.cpp
+++ b/src/engine_core/utils/src/SharedLibrary.cpp
@@ -40,29 +40,29 @@ Hush::SharedLibrary::~SharedLibrary()
 }
 
 Hush::Result<Hush::SharedLibrary, Hush::SharedLibrary::EError> Hush::SharedLibrary::OpenSharedLibrary(
-	std::string_view libraryName) noexcept
+	NullTerminatedStringView libraryName) noexcept
 {
 #if HUSH_PLATFORM_WIN
-	auto *handle = LoadLibraryA(libraryName.data());
+	auto *handle = LoadLibraryA(libraryName.c_str());
 #else
-	auto *handle = dlopen(libraryName.data(), RTLD_LAZY);
+	auto *handle = dlopen(libraryName.c_str(), RTLD_LAZY);
 
 #endif
 
 	if (handle == nullptr)
 	{
-		LogFormat(ELogLevel::Debug, "Failed to open library: {}", libraryName);
+		LogFormat(ELogLevel::Debug, "Failed to open library: {}", std::string_view(libraryName));
 		return EError::NotFound;
 	}
 	return SharedLibrary(handle);
 }
 
-void *Hush::SharedLibrary::GetRawSymbol(std::string_view symbolName)
+void *Hush::SharedLibrary::GetRawSymbol(NullTerminatedStringView symbolName)
 {
 #if HUSH_PLATFORM_WIN
 	auto *winHandle = static_cast<HMODULE>(m_nativeHandle);
 
-	return reinterpret_cast<void *>(GetProcAddress(winHandle, symbolName.data()));
+	return reinterpret_cast<void *>(GetProcAddress(winHandle, symbolName.c_str()));
 #else
 	return nullptr;
 #endif

--- a/src/engine_core/utils/src/SharedLibrary.hpp
+++ b/src/engine_core/utils/src/SharedLibrary.hpp
@@ -5,8 +5,8 @@
 */
 
 #pragma once
+#include <NullTerminatedStringView.hpp>
 #include <Result.hpp>
-#include <string_view>
 
 namespace Hush
 {
@@ -44,7 +44,7 @@ namespace Hush
 		/// @return A pointer to the symbol
 		template <typename T>
 		[[nodiscard]]
-		T *GetSymbolUnsafe(std::string_view symbolName)
+		T *GetSymbolUnsafe(NullTerminatedStringView symbolName)
 		{
 			return reinterpret_cast<T *>(GetRawSymbol(symbolName));
 		}
@@ -55,7 +55,7 @@ namespace Hush
 		/// @return A result with the symbol, or an error if it can't be found
 		template <typename T>
 		[[nodiscard]]
-		Result<T, EError> GetSymbol(std::string_view symbolName) noexcept
+		Result<T, EError> GetSymbol(NullTerminatedStringView symbolName) noexcept
 		{
 			auto symbol = GetSymbolUnsafe<T>(symbolName);
 			if (symbol == nullptr)
@@ -68,10 +68,10 @@ namespace Hush
 		/// Opens a shared library and returns a handle to it.
 		/// @param libraryName Shared Library name.
 		/// @return A handle to the shared library
-		static Result<SharedLibrary, EError> OpenSharedLibrary(std::string_view libraryName) noexcept;
+		static Result<SharedLibrary, EError> OpenSharedLibrary(NullTerminatedStringView libraryName) noexcept;
 
 	private:
-		void *GetRawSymbol(std::string_view symbolName);
+		void *GetRawSymbol(NullTerminatedStringView symbolName);
 
 		void *m_nativeHandle;
 	};

--- a/src/engine_core/utils/src/StringAllocation.hpp
+++ b/src/engine_core/utils/src/StringAllocation.hpp
@@ -18,12 +18,12 @@ namespace Hush
 {
 	/// Allocates a null-terminated copy of `sv` from `mr` and returns a view over it.
 	///
-	/// Use this function when you need to pass a string view to an API that requires a null-terminated string, 
+	/// Use this function when you need to pass a string view to an API that requires a null-terminated string,
 	/// and you want to avoid expensive allocations through the global heap.
 	/// The returned view is valid until the memory resource is reset or destroyed.
-	/// 
-	/// The most common memory resource for this is the frame-scoped allocator, and for strings that are meant to be used for
-	/// short-lived operations.
+	///
+	/// The most common memory resource for this is the frame-scoped allocator, and for strings that are meant to be
+	/// used for short-lived operations.
 	///
 	/// @param sv The (possibly non-null-terminated) source view to copy.
 	/// @param mr The memory resource to allocate from. Must not be null.

--- a/src/engine_core/utils/src/StringAllocation.hpp
+++ b/src/engine_core/utils/src/StringAllocation.hpp
@@ -1,0 +1,47 @@
+/*! \file StringAllocation.hpp
+	\author Alan Ramirez Herrera
+	\date 2026-07-01
+	\brief Helpers for materializing null-terminated strings from arbitrary string views,
+		   backed by a std::pmr memory resource (typically a frame or scene arena).
+*/
+
+#pragma once
+
+#include "Assertions.hpp"
+#include "NullTerminatedStringView.hpp"
+
+#include <cstring>
+#include <memory_resource>
+#include <string_view>
+
+namespace Hush
+{
+	/// Allocates a null-terminated copy of `sv` from `mr` and returns a view over it.
+	///
+	/// This is the bridge for the common case where an arbitrary — possibly non-null-terminated
+	/// — `std::string_view` must be handed to a C API (Flecs, Win32, ...) that requires a
+	/// `const char*`. Backing it with a frame or scene arena makes the copy a pointer bump that
+	/// is reclaimed in bulk, instead of a per-call `std::string` heap allocation.
+	///
+	/// The returned view is valid for as long as `mr` keeps the allocation alive — for a
+	/// monotonic frame/scene resource, until its next `Reset()`. The bytes are never freed
+	/// individually.
+	///
+	/// @param sv The (possibly non-null-terminated) source view to copy.
+	/// @param mr The memory resource to allocate from. Must not be null.
+	[[nodiscard]]
+	inline NullTerminatedStringView MakeNullTerminated(std::string_view sv, std::pmr::memory_resource *mr)
+	{
+		HUSH_ASSERT(mr != nullptr, "MakeNullTerminated requires a non-null memory resource");
+
+		// +1 for the null terminator.
+		char *buffer = static_cast<char *>(mr->allocate(sv.size() + 1, alignof(char)));
+		if (!sv.empty())
+		{
+			std::memcpy(buffer, sv.data(), sv.size());
+		}
+		buffer[sv.size()] = '\0';
+
+		return NullTerminatedStringView::promise_null_terminated(std::string_view{buffer, sv.size()});
+	}
+} // namespace Hush


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issues

<!-- Link any related issues. Use "Closes #123" to auto-close on merge. -->

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Documentation
- [ ] Build / CI
- [ ] Other

## Checklist

- [ ] Code compiles without warnings (MSVC + Clang)
- [x] I have formatted my code (`hush-devtool format` / `cargo fmt`)
- [ ] I have added/updated relevant documentation
- [ ] I have added/updated tests (if applicable)
- [ ] I have tested my changes locally

## Screenshots / Recordings

<!-- Optional — especially useful for rendering or visual changes. -->

## Additional Notes

<!-- Optional — anything reviewers should know. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added engine-managed frame- and scene-scoped memory pools, with new APIs to access the frame allocator and reset scene allocations.
  * Introduced pooled, cross-thread-safe coroutine-frame allocations.
  * Added `NullTerminatedStringView` support across shader compilation, scripting, shared-library loading, and component/tag lookups.
  * When enabling mimalloc, allocator selection is applied build-wide.
* **Bug Fixes**
  * Improved scene teardown and memory reset ordering for more reliable memory reuse.
* **Tests**
  * Added/expanded unit tests and benchmarks for the new memory resources and null-terminated string utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->