### PR TITLE
Feat buffer resizing

### DIFF
--- a/src/editor/src/systems/RenderingSystem.cpp
+++ b/src/editor/src/systems/RenderingSystem.cpp
@@ -241,7 +241,8 @@ void Hush::RenderingSystem::OnPreRender()
 	// Resize our mesh buffer if we get to the max amount of meshes
 	uint64_t currBufferSize = this->m_meshModelBuffer->GetSize();
 	constexpr uint64_t meshBufferGrowthFactor = 2;
-	if (meshCount > (currBufferSize / this->m_meshModelSlotSize)) {
+	if (meshCount > (currBufferSize / this->m_meshModelSlotSize))
+	{
 		device->ResizeBuffer(this->m_meshModelBuffer.get(), currBufferSize * meshBufferGrowthFactor);
 	}
 
@@ -518,17 +519,19 @@ Hush::Graphics::ShaderCompilationResult Hush::RenderingSystem::SetupMeshPipeline
 
 	// If we exceed the count of mesh instances here we need to call device->ResizeBuffer()
 	constexpr uint32_t initialMeshInstancePoolSize = 1024;
-	this->m_meshModelBuffer = device->CreateBuffer({.size = static_cast<uint64_t>(meshModelSlotSize) * initialMeshInstancePoolSize,
-													.usage = EBufferUsage::Uniform,
-													.memoryAccess = EMemoryAccess::CPUNone,
-													.debugName = "MeshModelBuffer"});
+	this->m_meshModelBuffer =
+		device->CreateBuffer({.size = static_cast<uint64_t>(meshModelSlotSize) * initialMeshInstancePoolSize,
+							  .usage = EBufferUsage::Uniform,
+							  .memoryAccess = EMemoryAccess::CPUNone,
+							  .debugName = "MeshModelBuffer"});
 
 	this->m_sceneDataBuffer = device->CreateBuffer({.size = sizeof(SceneData),
 													.usage = EBufferUsage::Uniform,
 													.memoryAccess = EMemoryAccess::CPUNone,
 													.debugName = "SceneDataBuffer"});
 
-	// This assumes the material will always be the default PBR, which is fine for a general buffer, but, we will need per material buffers
+	// This assumes the material will always be the default PBR, which is fine for a general buffer, but, we will need
+	// per material buffers
 	this->m_meshMaterialBuffer = device->CreateBuffer({.size = sizeof(PBRMaterialData),
 													   .usage = EBufferUsage::Uniform,
 													   .memoryAccess = EMemoryAccess::CPUNone,

--- a/src/editor/src/systems/RenderingSystem.cpp
+++ b/src/editor/src/systems/RenderingSystem.cpp
@@ -236,6 +236,15 @@ void Hush::RenderingSystem::OnPreRender()
 	Graphics::IGraphicsDevice *device = WindowManager::GetMainWindow()->GetGraphicsDevice();
 	uint32_t slotIndex = 0;
 
+	size_t meshCount = this->m_renderableTargetsQuery.begin().Size();
+
+	// Resize our mesh buffer if we get to the max amount of meshes
+	uint64_t currBufferSize = this->m_meshModelBuffer->GetSize();
+	constexpr uint64_t meshBufferGrowthFactor = 2;
+	if (meshCount > (currBufferSize / this->m_meshModelSlotSize)) {
+		device->ResizeBuffer(this->m_meshModelBuffer.get(), currBufferSize * meshBufferGrowthFactor);
+	}
+
 	m_renderableTargetsQuery.Each([this, device, &slotIndex](const MeshReference &meshRef,
 															 const WorldTransform &xform) {
 		const auto *mesh = meshRef.GetMesh().Get();
@@ -507,8 +516,9 @@ Hush::Graphics::ShaderCompilationResult Hush::RenderingSystem::SetupMeshPipeline
 	uint32_t meshModelSlotSize = (sizeof(ModelData) + minOffsetAlignment - 1) & ~(minOffsetAlignment - 1);
 	this->m_meshModelSlotSize = meshModelSlotSize;
 
-	constexpr uint32_t maxMeshInstances = 1024;
-	this->m_meshModelBuffer = device->CreateBuffer({.size = static_cast<uint64_t>(meshModelSlotSize) * maxMeshInstances,
+	// If we exceed the count of mesh instances here we need to call device->ResizeBuffer()
+	constexpr uint32_t initialMeshInstancePoolSize = 1024;
+	this->m_meshModelBuffer = device->CreateBuffer({.size = static_cast<uint64_t>(meshModelSlotSize) * initialMeshInstancePoolSize,
 													.usage = EBufferUsage::Uniform,
 													.memoryAccess = EMemoryAccess::CPUNone,
 													.debugName = "MeshModelBuffer"});
@@ -518,6 +528,7 @@ Hush::Graphics::ShaderCompilationResult Hush::RenderingSystem::SetupMeshPipeline
 													.memoryAccess = EMemoryAccess::CPUNone,
 													.debugName = "SceneDataBuffer"});
 
+	// This assumes the material will always be the default PBR, which is fine for a general buffer, but, we will need per material buffers
 	this->m_meshMaterialBuffer = device->CreateBuffer({.size = sizeof(PBRMaterialData),
 													   .usage = EBufferUsage::Uniform,
 													   .memoryAccess = EMemoryAccess::CPUNone,

--- a/src/editor/src/systems/RenderingSystem.hpp
+++ b/src/editor/src/systems/RenderingSystem.hpp
@@ -131,7 +131,8 @@ namespace Hush
 		std::unique_ptr<Graphics::IGraphicsTexture> m_defaultEmissiveTex;
 		std::unique_ptr<Graphics::ISampler> m_defaultSampler;
 
-		// This is a terrible map to keep here because we need to delete the entries when the resource manager frees up the pointer
+		// This is a terrible map to keep here because we need to delete the entries when the resource manager frees up
+		// the pointer
 		// ... That is not yet implemented and we should really pay attention to it later on
 		std::unordered_map<const Graphics::Material3D *, std::unique_ptr<Graphics::IBindGroup>>
 			m_materialBindGroupCache;

--- a/src/engine_core/rendering/src/RHI/GraphicsTypes.hpp
+++ b/src/engine_core/rendering/src/RHI/GraphicsTypes.hpp
@@ -365,6 +365,7 @@ namespace Hush::Graphics
 	struct BufferDescriptor
 	{
 		uint64_t size = 0;
+		uint64_t resizeBy = 0;
 		EBufferUsage usage = EBufferUsage::None;
 		EMemoryAccess memoryAccess = EMemoryAccess::CPUNone;
 		const char *debugName = nullptr;

--- a/src/engine_core/rendering/src/RHI/GraphicsTypes.hpp
+++ b/src/engine_core/rendering/src/RHI/GraphicsTypes.hpp
@@ -365,7 +365,6 @@ namespace Hush::Graphics
 	struct BufferDescriptor
 	{
 		uint64_t size = 0;
-		uint64_t resizeBy = 0;
 		EBufferUsage usage = EBufferUsage::None;
 		EMemoryAccess memoryAccess = EMemoryAccess::CPUNone;
 		const char *debugName = nullptr;

--- a/src/engine_core/rendering/src/RHI/IGraphicsBuffer.hpp
+++ b/src/engine_core/rendering/src/RHI/IGraphicsBuffer.hpp
@@ -31,6 +31,11 @@ namespace Hush::Graphics
 		[[nodiscard]]
 		virtual EBufferUsage GetUsage() const = 0;
 
+		[[nodiscard]]
+		virtual const BufferDescriptor &GetDescriptor() const = 0;
+
+		virtual void Destroy() = 0;
+
 		/// @brief Map buffer for CPU access (if supported)
 		///
 		/// @param device Non-owning pointer to the graphics device (may be needed for some APIs to perform the mapping)

--- a/src/engine_core/rendering/src/RHI/IGraphicsDevice.hpp
+++ b/src/engine_core/rendering/src/RHI/IGraphicsDevice.hpp
@@ -71,6 +71,11 @@ namespace Hush::Graphics
 		/// @param size    Number of bytes to write.
 		virtual void WriteBuffer(IGraphicsBuffer *buffer, uint64_t offset, const void *data, uint64_t size) = 0;
 
+		/// @brief Dynamically resizes the GPU-side buffer
+		/// this implies destroying the current buffer and creating a new one with
+		/// an identical descriptor expanded in size
+		virtual void ResizeBuffer(size_t size, IGraphicsBuffer *buffer) = 0;
+
 		/// @brief Create a texture
 		/// @param descriptor Texture creation parameters
 		/// @return Created texture, or nullptr on failure

--- a/src/engine_core/rendering/src/RHI/IGraphicsDevice.hpp
+++ b/src/engine_core/rendering/src/RHI/IGraphicsDevice.hpp
@@ -18,6 +18,7 @@
 #include "PipelineDescriptor.hpp"
 #include "ShaderCompiler.hpp"
 #include "Logger.hpp"
+#include <cstdint>
 #include <memory>
 #include <functional>
 
@@ -74,7 +75,7 @@ namespace Hush::Graphics
 		/// @brief Dynamically resizes the GPU-side buffer
 		/// this implies destroying the current buffer and creating a new one with
 		/// an identical descriptor expanded in size
-		virtual void ResizeBuffer(size_t size, IGraphicsBuffer *buffer) = 0;
+		virtual void ResizeBuffer(IGraphicsBuffer *buffer, uint64_t size) = 0;
 
 		/// @brief Create a texture
 		/// @param descriptor Texture creation parameters

--- a/src/engine_core/rendering/src/WebGPU/WebGPUBuffer.cpp
+++ b/src/engine_core/rendering/src/WebGPU/WebGPUBuffer.cpp
@@ -4,6 +4,7 @@
 	\brief WebGPU buffer implementation
 */
 #include "WebGPUBuffer.hpp"
+#include "RHI/GraphicsTypes.hpp"
 #include "WebGPU/WebGPUGraphicsDevice.hpp"
 #include "Assertions.hpp"
 #include "Logger.hpp"
@@ -25,6 +26,14 @@ namespace Hush::Graphics
 
 	WebGPUBuffer::~WebGPUBuffer()
 	{
+		if (m_mappedData != nullptr)
+		{
+			Unmap();
+		}
+		m_buffer.destroy();
+	}
+
+	void WebGPUBuffer::Destroy() {
 		if (m_mappedData != nullptr)
 		{
 			Unmap();

--- a/src/engine_core/rendering/src/WebGPU/WebGPUBuffer.cpp
+++ b/src/engine_core/rendering/src/WebGPU/WebGPUBuffer.cpp
@@ -33,7 +33,8 @@ namespace Hush::Graphics
 		m_buffer.destroy();
 	}
 
-	void WebGPUBuffer::Destroy() {
+	void WebGPUBuffer::Destroy()
+	{
 		if (m_mappedData != nullptr)
 		{
 			Unmap();

--- a/src/engine_core/rendering/src/WebGPU/WebGPUBuffer.hpp
+++ b/src/engine_core/rendering/src/WebGPU/WebGPUBuffer.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "../RHI/IGraphicsBuffer.hpp"
+#include "WebGPU/WebGPUGraphicsDevice.hpp"
 #include <webgpu/webgpu.hpp>
 
 namespace Hush::Graphics
@@ -32,6 +33,14 @@ namespace Hush::Graphics
 		{
 			return m_descriptor.usage;
 		}
+
+		[[nodiscard]]
+		const BufferDescriptor &GetDescriptor() const override {
+			return this->m_descriptor;
+		}
+
+		void Destroy() override;
+
 		void *Map(Graphics::IGraphicsDevice *device) override;
 		void Unmap() override;
 		[[nodiscard]]
@@ -48,6 +57,8 @@ namespace Hush::Graphics
 		wgpu::Instance m_instance;
 		BufferDescriptor m_descriptor;
 		void *m_mappedData = nullptr;
+
+		friend class WebGPUGraphicsDevice;
 	};
 
 } // namespace Hush::Graphics

--- a/src/engine_core/rendering/src/WebGPU/WebGPUBuffer.hpp
+++ b/src/engine_core/rendering/src/WebGPU/WebGPUBuffer.hpp
@@ -35,7 +35,8 @@ namespace Hush::Graphics
 		}
 
 		[[nodiscard]]
-		const BufferDescriptor &GetDescriptor() const override {
+		const BufferDescriptor &GetDescriptor() const override
+		{
 			return this->m_descriptor;
 		}
 

--- a/src/engine_core/rendering/src/WebGPU/WebGPUGraphicsDevice.cpp
+++ b/src/engine_core/rendering/src/WebGPU/WebGPUGraphicsDevice.cpp
@@ -19,6 +19,7 @@
 #include "Assertions.hpp"
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_video.h>
+#include <cstdint>
 #include <sdl3webgpu/sdl3webgpu.h>
 #include <magic_enum/magic_enum.hpp>
 #include <webgpu/webgpu.hpp>
@@ -197,7 +198,7 @@ namespace Hush::Graphics
 		return m_capabilities;
 	}
 
-	std::unique_ptr<IGraphicsBuffer> WebGPUGraphicsDevice::CreateBuffer(const BufferDescriptor &descriptor)
+	wgpu::Buffer WebGPUGraphicsDevice::CreateBufferInternal(const BufferDescriptor &descriptor)
 	{
 		ZoneScoped;
 		wgpu::BufferDescriptor desc{};
@@ -232,6 +233,17 @@ namespace Hush::Graphics
 		if (buffer == nullptr)
 		{
 			LogError("Failed to create WebGPU buffer");
+		}
+
+		return buffer;
+	}
+
+	std::unique_ptr<IGraphicsBuffer> WebGPUGraphicsDevice::CreateBuffer(const BufferDescriptor &descriptor)
+	{
+		wgpu::Buffer buffer = this->CreateBufferInternal(descriptor);
+		if (buffer == nullptr)
+		{
+			// Error is logged on the internal function
 			return nullptr;
 		}
 
@@ -254,6 +266,56 @@ namespace Hush::Graphics
 
 		wgpu::Queue queue = m_device.getQueue();
 		queue.writeBuffer(webgpuBuffer->GetBuffer(), offset, data, static_cast<size_t>(size));
+	}
+
+	void WebGPUGraphicsDevice::ResizeBuffer(size_t size, IGraphicsBuffer *buffer)
+	{
+		// There is an available descriptor, we just copy that, obviously this is an intentional copy-op
+		BufferDescriptor newDesc = buffer->GetDescriptor();
+		newDesc.size = size;
+
+		// Copy the original buffer back to the new one
+		// Create a new buffer with the updated size and map it
+		wgpu::Buffer buff = this->CreateBufferInternal(newDesc);
+		uint64_t oldBuffSize = buffer->GetSize();
+
+		if (buff == nullptr)
+		{
+			LogFormat(ELogLevel::Error, "Failed to resize buffer on buffer creation");
+			return;
+		}
+
+		if (oldBuffSize > 0)
+		{
+			uint64_t bytesToCopy = std::min(size, oldBuffSize);
+			// Handle alignment for WebGPU (multiples of 4)
+			uint64_t remainder = bytesToCopy % 4;
+			if (remainder != 0)
+			{
+				bytesToCopy = bytesToCopy + 4 - remainder;
+			}
+
+			// Encoder stuff, we do this raw instead of going through the abstractions
+			// because it is easier and we don't mess with lifetimes
+			this->m_graphicsQueue->Submit({});
+			wgpu::CommandEncoder encoder = this->m_device.createCommandEncoder();
+			wgpu::Buffer oldBuffer = static_cast<WGPUBuffer>(buffer->GetNativeHandle());
+			encoder.copyBufferToBuffer(oldBuffer, 0, buff, 0, bytesToCopy);
+
+			wgpu::CommandBuffer cmdBuffer = encoder.finish();
+			wgpu::Queue nativeQueue = static_cast<WGPUQueue>(this->m_graphicsQueue->GetNativeHandle());
+
+			nativeQueue.submit(cmdBuffer);
+		}
+
+		// Destroy the current buffer
+		buffer->Destroy();
+
+		// Just set the data
+		auto *bufferImpl = dynamic_cast<WebGPUBuffer *>(buffer);
+		bufferImpl->m_buffer = buff;
+		bufferImpl->m_instance = this->m_instance;
+		bufferImpl->m_descriptor = newDesc;
 	}
 
 	std::unique_ptr<IGraphicsTexture> WebGPUGraphicsDevice::CreateTexture(const TextureDescriptor &descriptor)

--- a/src/engine_core/rendering/src/WebGPU/WebGPUGraphicsDevice.cpp
+++ b/src/engine_core/rendering/src/WebGPU/WebGPUGraphicsDevice.cpp
@@ -19,7 +19,6 @@
 #include "Assertions.hpp"
 #include <SDL3/SDL.h>
 #include <SDL3/SDL_video.h>
-#include <cstdint>
 #include <sdl3webgpu/sdl3webgpu.h>
 #include <magic_enum/magic_enum.hpp>
 #include <webgpu/webgpu.hpp>
@@ -268,8 +267,11 @@ namespace Hush::Graphics
 		queue.writeBuffer(webgpuBuffer->GetBuffer(), offset, data, static_cast<size_t>(size));
 	}
 
-	void WebGPUGraphicsDevice::ResizeBuffer(size_t size, IGraphicsBuffer *buffer)
+	void WebGPUGraphicsDevice::ResizeBuffer(IGraphicsBuffer *buffer, uint64_t size)
 	{
+		HUSH_ASSERT(size < this->m_capabilities.maxBufferSize,
+					"Cannot resize buffer size to {}, maximum buffer size for this graphics device is: {}", size,
+					this->m_capabilities.maxBufferSize);
 		// There is an available descriptor, we just copy that, obviously this is an intentional copy-op
 		BufferDescriptor newDesc = buffer->GetDescriptor();
 		newDesc.size = size;
@@ -288,16 +290,16 @@ namespace Hush::Graphics
 		if (oldBuffSize > 0)
 		{
 			uint64_t bytesToCopy = std::min(size, oldBuffSize);
-			// Handle alignment for WebGPU (multiples of 4)
+			// Handle alignment for WebGPU (multiples of 4 rounding down to avoid writing out of bounds)
 			uint64_t remainder = bytesToCopy % 4;
 			if (remainder != 0)
 			{
-				bytesToCopy = bytesToCopy + 4 - remainder;
+				// Maybe we should issue a warning for the round down(? TBD on PR
+				bytesToCopy = (bytesToCopy / 4) * 4;
 			}
 
 			// Encoder stuff, we do this raw instead of going through the abstractions
 			// because it is easier and we don't mess with lifetimes
-			this->m_graphicsQueue->Submit({});
 			wgpu::CommandEncoder encoder = this->m_device.createCommandEncoder();
 			wgpu::Buffer oldBuffer = static_cast<WGPUBuffer>(buffer->GetNativeHandle());
 			encoder.copyBufferToBuffer(oldBuffer, 0, buff, 0, bytesToCopy);

--- a/src/engine_core/rendering/src/WebGPU/WebGPUGraphicsDevice.cpp
+++ b/src/engine_core/rendering/src/WebGPU/WebGPUGraphicsDevice.cpp
@@ -269,11 +269,15 @@ namespace Hush::Graphics
 
 	void WebGPUGraphicsDevice::ResizeBuffer(IGraphicsBuffer *buffer, uint64_t size)
 	{
-		HUSH_ASSERT(size < this->m_capabilities.maxBufferSize,
+		HUSH_ASSERT(size <= this->m_capabilities.maxBufferSize,
 					"Cannot resize buffer size to {}, maximum buffer size for this graphics device is: {}", size,
 					this->m_capabilities.maxBufferSize);
 		// There is an available descriptor, we just copy that, obviously this is an intentional copy-op
 		BufferDescriptor newDesc = buffer->GetDescriptor();
+		HUSH_ASSERT(
+			Bitwise::HasCompositeFlag(newDesc.usage, EBufferUsage::CopySource),
+			"For a buffer to be resized it needs to have the CopySource usage flag, current buffer's usage flags: {}",
+			newDesc.usage);
 		newDesc.size = size;
 
 		// Copy the original buffer back to the new one

--- a/src/engine_core/rendering/src/WebGPU/WebGPUGraphicsDevice.hpp
+++ b/src/engine_core/rendering/src/WebGPU/WebGPUGraphicsDevice.hpp
@@ -52,6 +52,8 @@ namespace Hush::Graphics
 
 		void WriteBuffer(IGraphicsBuffer *buffer, uint64_t offset, const void *data, uint64_t size) override;
 
+		void ResizeBuffer(size_t size, IGraphicsBuffer *buffer) override;
+
 		[[nodiscard]]
 		std::unique_ptr<IGraphicsTexture> CreateTexture(const TextureDescriptor &descriptor) override;
 
@@ -177,6 +179,8 @@ namespace Hush::Graphics
 		static void OnDeviceLost(WGPUDeviceLostReason reason, char const *message, void *userdata);
 
 	private:
+		wgpu::Buffer CreateBufferInternal(const BufferDescriptor &descriptor);
+
 		// WebGPU objects
 		wgpu::Instance m_instance;
 		wgpu::Adapter m_adapter;

--- a/src/engine_core/rendering/src/WebGPU/WebGPUGraphicsDevice.hpp
+++ b/src/engine_core/rendering/src/WebGPU/WebGPUGraphicsDevice.hpp
@@ -52,7 +52,7 @@ namespace Hush::Graphics
 
 		void WriteBuffer(IGraphicsBuffer *buffer, uint64_t offset, const void *data, uint64_t size) override;
 
-		void ResizeBuffer(size_t size, IGraphicsBuffer *buffer) override;
+		void ResizeBuffer(IGraphicsBuffer *buffer, uint64_t size) override;
 
 		[[nodiscard]]
 		std::unique_ptr<IGraphicsTexture> CreateTexture(const TextureDescriptor &descriptor) override;


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR does and why. -->

## Related Issues

<!-- Link any related issues. Use "Closes #123" to auto-close on merge. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Documentation
- [ ] Build / CI
- [ ] Other

## Checklist

- [ ] Code compiles without warnings (MSVC + Clang)
- [ ] I have formatted my code (`hush-devtool format` / `cargo fmt`)
- [ ] I have added/updated relevant documentation
- [ ] I have added/updated tests (if applicable)
- [ ] I have tested my changes locally

## Screenshots / Recordings

<!-- Optional — especially useful for rendering or visual changes. -->

## Additional Notes

<!-- Optional — anything reviewers should know. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resizing existing GPU buffers at runtime.
  * Preserves existing buffer data when resizing, up to the new buffer capacity.
  * Added explicit buffer destruction and descriptor access support.
* **Bug Fixes**
  * Ensures mapped buffers are unmapped before being destroyed.
  * Safely releases and replaces underlying resources during buffer resizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->